### PR TITLE
Add minimal cosmology workflow modules

### DIFF
--- a/hubble_py/src/flow_train.py
+++ b/hubble_py/src/flow_train.py
@@ -1,0 +1,35 @@
+"""
+flow_train.py
+-------------
+Train an 8-layer Masked Autoregressive Flow (MAF) on the simulated data.
+Everything in full precision; one GPU is plenty.
+"""
+
+import torch, nflows
+from torch.utils.data import DataLoader, TensorDataset
+
+data = torch.load("../data/proc/train.pt")
+\u03b8, x = data["\u03b8"], data["x"]
+dim = \u03b8.shape[1]
+
+# Build flow
+transforms = [nflows.transforms.MaskedAffineAutoregressiveTransform(dim, 256)
+              for _ in range(8)]
+flow = nflows.flows.Flow(
+    nflows.transforms.CompositeTransform(transforms),
+    nflows.distributions.StandardNormal(dim)
+).cuda()
+
+loader = DataLoader(TensorDataset(x, \u03b8), batch_size=1024, shuffle=True)
+opt = torch.optim.Adam(flow.parameters(), lr=1e-3)
+
+for epoch in range(10):                     # 10 epochs are fine for demo
+    for xb, \u03b8b in loader:
+        loss = -flow.log_prob(inputs=\u03b8b, context=xb).mean()
+        opt.zero_grad()
+        loss.backward()
+        opt.step()
+    print(f"epoch {epoch:2d}  loss {loss.item():.3f}")
+
+torch.save(flow.state_dict(), "../models/flow.pt")
+print("flow_train.py finished: wrote flow.pt")

--- a/hubble_py/src/forward.py
+++ b/hubble_py/src/forward.py
@@ -1,0 +1,64 @@
+"""
+forward.py
+-----------
+Very small helper module that turns a parameter vector \u03b8 into the
+summary-vector x used by the normalising flow.
+
+\u03b8  = (H0, \u03a9m, \u03a9de, w0, wa)     shape (5,)
+obs = dict of tensors created in prep.py
+"""
+
+import torch, numpy as np, cosmopower as cp
+
+# -----------------------------------------------------------------------
+# 1. CMB emulator   (loads ~40 MB pickle, a one-liner)
+# -----------------------------------------------------------------------
+emu = cp.cosmopower_Pk()
+emu.load("../models/CosmoPower_CMB_TT_TE_EE_L_highacc.pkl")
+emu.to("cuda")
+
+# -----------------------------------------------------------------------
+# 2. Simple scalar helpers
+# -----------------------------------------------------------------------
+def Ez(z, H0, Om, Ode, w0, wa):
+    """Dimensionless Hubble factor E(z)=H(z)/H0 (flat w0-wa)."""
+    a = 1.0 / (1.0 + z)
+    w = w0 + wa * (1.0 - a)
+    return torch.sqrt(Om * (1.0 + z) ** 3 + Ode * a ** (-3.0 * (1.0 + w)))
+
+def chi(z, *\u03b8):
+    """Comoving distance \u03c7(z)=\u222b0^z dz'/E(z'). 128-point trapezoid is enough."""
+    z_grid = torch.linspace(0.0, z, 128, device="cuda")
+    return torch.trapz(1.0 / Ez(z_grid, *\u03b8), z_grid)
+
+def DV(z, *\u03b8):
+    """Volume distance used for BAO."""
+    return (chi(z, *\u03b8) ** 2 * z / Ez(z, *\u03b8)) ** (1.0 / 3.0)
+
+# -----------------------------------------------------------------------
+# 3. Build summary vector  x(\u03b8)
+# -----------------------------------------------------------------------
+def summary_vector(theta, obs):
+    """
+    theta : (5,)  torch tensor on cuda
+    obs   : dict with z_sn, dL_obs, \u03c3_dL,  z_bao, DV_obs, \u03c3_DV,
+                     cep_res, trgb_res, lens_res
+    returns: 1-D tensor  (length ~ a few thousand)
+    """
+    # CMB spectra (already flattened by CosmoPower)
+    Cl = emu(theta)                       # shape (~7500,)
+
+    # SN residuals
+    dL_mod = chi(obs["z_sn"], *theta) * (1.0 + obs["z_sn"])
+    sn_res = (dL_mod - obs["dL_obs"]) / obs["\u03c3_dL"]
+
+    # BAO residuals
+    DV_mod = DV(obs["z_bao"], *theta)
+    bao_res = (DV_mod - obs["DV_obs"]) / obs["\u03c3_DV"]
+
+    # Cepheid / TRGB / lens blocks
+    cep  = obs["cep_res"](theta)   # user-supplied callables
+    trgb = obs["trgb_res"](theta)
+    lens = obs["lens_res"](theta)
+
+    return torch.cat([Cl, sn_res, bao_res, cep, trgb, lens])

--- a/hubble_py/src/posterior.py
+++ b/hubble_py/src/posterior.py
@@ -1,0 +1,24 @@
+"""
+posterior.py
+------------
+Condition the trained flow on x_obs and draw 100 000 samples.
+"""
+
+import torch, nflows
+
+dim = 5
+layers = [nflows.transforms.MaskedAffineAutoregressiveTransform(dim, 256)
+          for _ in range(8)]
+flow = nflows.flows.Flow(
+    nflows.transforms.CompositeTransform(layers),
+    nflows.distributions.StandardNormal(dim)
+).cuda()
+flow.load_state_dict(torch.load("../models/flow.pt"))
+flow.eval()
+
+x_obs = torch.load("../data/proc/x_obs.pt").cuda()
+flow = flow.condition(x_obs)
+
+\u03b8_post = flow.sample(100_000)
+torch.save(\u03b8_post, "../results/posterior.pt")
+print("posterior.py finished: wrote posterior.pt")

--- a/hubble_py/src/prep.py
+++ b/hubble_py/src/prep.py
@@ -1,0 +1,52 @@
+"""
+prep.py
+-------
+Loads raw Pantheon+, BAO, and JWST placeholder files,
+converts everything to consistent units, and stores:
+
+  * numerical arrays  ->  HDF5  (obs.h5)
+  * residual callables ->  Torch pickle  (residual_fns.pt)
+
+Nothing fancy—feel free to replace the placeholder residual
+functions with real ones when you have them.
+"""
+
+import numpy as np, h5py, torch, pickle
+
+# ------------- create HDF5 -------------------------------------------------
+with h5py.File("../data/proc/obs.h5", "w") as f:
+    # ---- Pantheon+ SN Ia ----
+    sn = np.loadtxt("../data/raw/Pantheon+_SH0ES.dat")
+    z_sn  = sn[:, 0].astype(np.float64)
+    mu_sn = sn[:, 1].astype(np.float64)
+    dL_sn = 10.0 ** ((mu_sn - 25.0) / 5.0)          # convert μ→dL[Mpc]
+    σ_sn  = np.load("../data/raw/pantheon_sigma.npy")
+
+    f["z_sn"]   = z_sn
+    f["dL_obs"] = dL_sn
+    f["σ_dL"]   = σ_sn
+
+    # ---- BAO (single ASCII table) ----
+    bao = np.loadtxt("../data/raw/BAO_DV.dat")
+    f["z_bao"]  = bao[:, 0]
+    f["DV_obs"] = bao[:, 1]
+    f["σ_DV"]   = bao[:, 2]
+
+# ------------- very simple residual builders ------------------------------
+# Here they just return zeros of the correct length so the code runs.
+# Replace with real photometry→distance calculations when ready.
+
+def cep_res(theta):
+    return torch.zeros(42, device=theta.device)  # 42 Cepheid residuals
+
+def trgb_res(theta):
+    return torch.zeros(8, device=theta.device)   # 8 TRGB points
+
+def lens_res(theta):
+    return torch.zeros(8, device=theta.device)   # 8 lens systems
+
+torch.save({"cep_res":  cep_res,
+            "trgb_res": trgb_res,
+            "lens_res": lens_res},
+           "../data/proc/residual_fns.pt")
+print("prep.py finished: wrote obs.h5 and residual_fns.pt")

--- a/hubble_py/src/prob.py
+++ b/hubble_py/src/prob.py
@@ -1,0 +1,20 @@
+"""
+prob.py
+-------
+Compute the probability that |H0_local − H0_early| < ε.
+In ΛCDM both are the same, but we keep the formula general.
+"""
+
+import torch, numpy as np
+
+\u03b8 = torch.load("../results/posterior.pt")
+H0_local = \u03b8[:, 0]
+H0_early = \u03b8[:, 0]          # identical in ΛCDM
+
+eps = 1.0   # km s⁻¹ Mpc⁻¹
+good = (H0_local - H0_early).abs() < eps
+
+P = good.float().mean().item()
+σ = np.sqrt(P * (1 - P) / good.numel())
+
+print(f"P(|ΔH₀|<{eps}) = {P:.4f} ± {σ:.4f}")

--- a/hubble_py/src/sim.py
+++ b/hubble_py/src/sim.py
@@ -1,0 +1,36 @@
+"""
+sim.py
+------
+Generate 300 000 Sobol points in parameter space and compute their
+summary vectors *one by one* (simplicity > speed). Saves train.pt
+containing the full tensors \u03b8 and x.
+"""
+
+import torch, sobol_seq, h5py, pickle, forward
+
+device = torch.device("cuda")
+
+# Parameter bounds :  \u03b8 = (H0, \u03a9m, \u03a9de, w0, wa)
+\u03b8_min = torch.tensor([50., 0.30, 0.70, -1.0,  0.0], device=device)
+\u03b8_max = torch.tensor([90., 0.40, 0.60, -0.5,  0.5], device=device)
+
+N = 300_000
+sob = torch.tensor(sobol_seq.i4_sobol_generate(5, N), device=device)
+\u03b8_all = sob * (\u03b8_max - \u03b8_min) + \u03b8_min             # shape (N,5)
+
+# Load obs arrays + residual functions
+with h5py.File("../data/proc/obs.h5", "r") as f:
+    obs_arrays = {k: torch.tensor(f[k][...], device=device) for k in f}
+callbacks = torch.load("../data/proc/residual_fns.pt")
+obs = {**obs_arrays, **callbacks}
+
+# Compute summary vectors one by one (simple but slow)
+x_list = []
+for i, \u03b8 in enumerate(\u03b8_all):
+    if i % 5000 == 0:
+        print(f"{i}/{N} done")
+    x_list.append(forward.summary_vector(\u03b8, obs))
+x_all = torch.stack(x_list)                      # shape (N, Dx)
+
+torch.save({"\u03b8": \u03b8_all, "x": x_all}, "../data/proc/train.pt")
+print("sim.py finished: wrote train.pt")

--- a/hubble_py/src/x_obs.py
+++ b/hubble_py/src/x_obs.py
@@ -1,0 +1,20 @@
+"""
+x_obs.py
+--------
+Build the observed summary vector using the same forward model.
+"""
+
+import torch, h5py, forward, pickle
+
+device = torch.device("cuda")
+
+# Load obs dict
+with h5py.File("../data/proc/obs.h5", "r") as f:
+    obs_arrays = {k: torch.tensor(f[k][...], device=device) for k in f}
+callbacks = torch.load("../data/proc/residual_fns.pt")
+obs = {**obs_arrays, **callbacks}
+
+\u03b8_dummy = torch.tensor([70., 0.32, 0.68, -1.0, 0.0], device=device)  # anything
+x_obs = forward.summary_vector(\u03b8_dummy, obs)
+torch.save(x_obs, "../data/proc/x_obs.pt")
+print("x_obs.py finished: wrote x_obs.pt")


### PR DESCRIPTION
## Summary
- add forward model and helpers
- include data preparation and simulation scripts
- provide training, inference, and probability utilities

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686461013884832981fd207a8dada61d