### PR TITLE
Add Bayesian model comparison and Hubble tension quantification

### DIFF
--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -1,0 +1,19 @@
+"""
+analysis/__init__.py
+--------------------
+Analysis and visualization modules.
+"""
+
+from analysis.visualize import (
+    plot_corner,
+    plot_tension_curve,
+    plot_model_comparison,
+    plot_H0_posteriors,
+)
+
+__all__ = [
+    "plot_corner",
+    "plot_tension_curve",
+    "plot_model_comparison",
+    "plot_H0_posteriors",
+]

--- a/analysis/visualize.py
+++ b/analysis/visualize.py
@@ -1,0 +1,374 @@
+"""
+analysis/visualize.py
+---------------------
+Visualization tools for Hubble results.
+
+Generates publication-quality plots:
+- Corner plots of posterior distributions
+- H₀ tension visualization
+- Model comparison plots
+- Resolution probability curves
+"""
+
+import numpy as np
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple, Any
+import warnings
+
+from config import paths, logger
+from cosmology.base import CosmologicalModel
+
+# Lazy import matplotlib to avoid issues if not installed
+_plt = None
+_corner = None
+
+
+def _get_plt():
+    global _plt
+    if _plt is None:
+        try:
+            import matplotlib.pyplot as plt
+            plt.style.use('seaborn-v0_8-whitegrid')
+            _plt = plt
+        except ImportError:
+            raise ImportError("matplotlib required for plotting. Install with: pip install matplotlib")
+    return _plt
+
+
+def _get_corner():
+    global _corner
+    if _corner is None:
+        try:
+            import corner
+            _corner = corner
+        except ImportError:
+            warnings.warn("corner package not installed. Install with: pip install corner")
+            _corner = None
+    return _corner
+
+
+def plot_corner(
+    theta_samples,
+    model: CosmologicalModel,
+    truths: Optional[List[float]] = None,
+    output_path: Optional[Path] = None,
+    title: Optional[str] = None,
+    **kwargs
+) -> Any:
+    """
+    Create a corner plot of posterior samples.
+
+    Parameters
+    ----------
+    theta_samples : torch.Tensor or np.ndarray
+        Posterior samples, shape (n_samples, n_params)
+    model : CosmologicalModel
+        Model for parameter names/labels
+    truths : list, optional
+        True parameter values to mark
+    output_path : Path, optional
+        Where to save the figure
+    title : str, optional
+        Plot title
+    **kwargs
+        Additional arguments to corner.corner
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+        The corner plot figure
+    """
+    plt = _get_plt()
+    corner = _get_corner()
+
+    if corner is None:
+        warnings.warn("corner package not available, skipping corner plot")
+        return None
+
+    # Convert to numpy
+    if hasattr(theta_samples, 'cpu'):
+        samples = theta_samples.cpu().numpy()
+    else:
+        samples = np.asarray(theta_samples)
+
+    # Default kwargs
+    default_kwargs = {
+        "labels": model.param_symbols,
+        "quantiles": [0.16, 0.5, 0.84],
+        "show_titles": True,
+        "title_kwargs": {"fontsize": 12},
+        "label_kwargs": {"fontsize": 14},
+    }
+    default_kwargs.update(kwargs)
+
+    if truths is not None:
+        default_kwargs["truths"] = truths
+
+    fig = corner.corner(samples, **default_kwargs)
+
+    if title:
+        fig.suptitle(title, fontsize=16, y=1.02)
+
+    if output_path:
+        fig.savefig(output_path, dpi=150, bbox_inches='tight')
+        logger.info(f"Saved corner plot to {output_path}")
+
+    return fig
+
+
+def plot_tension_curve(
+    tension_curve: Dict[str, np.ndarray],
+    output_path: Optional[Path] = None,
+    title: str = "Hubble Tension Resolution Probability",
+) -> Any:
+    """
+    Plot P(|ΔH₀| < ε) as a function of ε.
+
+    Parameters
+    ----------
+    tension_curve : dict
+        Output from TensionAnalyzer.probability_curve()
+        {"epsilon": [...], "probability": [...], "std_error": [...]}
+    output_path : Path, optional
+        Where to save the figure
+    title : str
+        Plot title
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+    """
+    plt = _get_plt()
+
+    fig, ax = plt.subplots(figsize=(8, 6))
+
+    eps = tension_curve["epsilon"]
+    prob = tension_curve["probability"]
+    err = tension_curve["std_error"]
+
+    ax.errorbar(eps, prob, yerr=err, fmt='o-', capsize=4, linewidth=2, markersize=8)
+    ax.axhline(0.5, color='gray', linestyle='--', alpha=0.5, label='50% threshold')
+
+    ax.set_xlabel("ε (km/s/Mpc)", fontsize=14)
+    ax.set_ylabel("P(|ΔH₀| < ε)", fontsize=14)
+    ax.set_title(title, fontsize=16)
+    ax.set_ylim(0, 1.05)
+    ax.set_xlim(0, max(eps) * 1.1)
+    ax.legend(fontsize=12)
+    ax.grid(True, alpha=0.3)
+
+    # Add interpretation zones
+    ax.axhspan(0, 0.05, alpha=0.1, color='red', label='Strong tension')
+    ax.axhspan(0.05, 0.32, alpha=0.1, color='orange')
+    ax.axhspan(0.32, 1.0, alpha=0.1, color='green')
+
+    plt.tight_layout()
+
+    if output_path:
+        fig.savefig(output_path, dpi=150, bbox_inches='tight')
+        logger.info(f"Saved tension curve to {output_path}")
+
+    return fig
+
+
+def plot_model_comparison(
+    comparison_result,
+    output_path: Optional[Path] = None,
+) -> Any:
+    """
+    Plot model comparison results.
+
+    Parameters
+    ----------
+    comparison_result : ComparisonResult
+        Output from ModelComparison.compare()
+    output_path : Path, optional
+        Where to save the figure
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+    """
+    plt = _get_plt()
+
+    fig, axes = plt.subplots(1, 2, figsize=(14, 5))
+
+    # Left: Log evidence
+    ax1 = axes[0]
+    names = [mr.model.short_name for mr in comparison_result.models]
+    log_evs = [mr.log_evidence for mr in comparison_result.models]
+    log_ev_stds = [mr.evidence.log_evidence_std for mr in comparison_result.models]
+
+    y_pos = np.arange(len(names))
+    ax1.barh(y_pos, log_evs, xerr=log_ev_stds, align='center', alpha=0.8)
+    ax1.set_yticks(y_pos)
+    ax1.set_yticklabels(names, fontsize=12)
+    ax1.set_xlabel("log Evidence", fontsize=14)
+    ax1.set_title("Model Evidence", fontsize=16)
+
+    # Right: Model probabilities
+    ax2 = axes[1]
+    probs = [comparison_result.model_probabilities[n] for n in names]
+
+    bars = ax2.barh(y_pos, probs, align='center', alpha=0.8)
+    ax2.set_yticks(y_pos)
+    ax2.set_yticklabels(names, fontsize=12)
+    ax2.set_xlabel("Posterior Probability", fontsize=14)
+    ax2.set_title("Model Probabilities (equal priors)", fontsize=16)
+    ax2.set_xlim(0, 1)
+
+    # Add percentage labels
+    for bar, prob in zip(bars, probs):
+        ax2.text(bar.get_width() + 0.02, bar.get_y() + bar.get_height()/2,
+                f'{prob:.1%}', va='center', fontsize=12)
+
+    plt.tight_layout()
+
+    if output_path:
+        fig.savefig(output_path, dpi=150, bbox_inches='tight')
+        logger.info(f"Saved model comparison to {output_path}")
+
+    return fig
+
+
+def plot_H0_posteriors(
+    posteriors: Dict[str, Tuple[np.ndarray, CosmologicalModel]],
+    output_path: Optional[Path] = None,
+    reference_values: Optional[Dict[str, float]] = None,
+) -> Any:
+    """
+    Plot H₀ posterior distributions from multiple models.
+
+    Parameters
+    ----------
+    posteriors : dict
+        {model_name: (theta_samples, model)} for each model
+    output_path : Path, optional
+        Where to save the figure
+    reference_values : dict, optional
+        Reference H₀ values to mark, e.g., {"Planck": 67.4, "SH0ES": 73.0}
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+    """
+    plt = _get_plt()
+
+    fig, ax = plt.subplots(figsize=(10, 6))
+
+    colors = plt.cm.tab10(np.linspace(0, 1, len(posteriors)))
+
+    for (name, (samples, model)), color in zip(posteriors.items(), colors):
+        # Get H0 (could be early or late depending on model)
+        if hasattr(samples, 'cpu'):
+            samples = samples.cpu()
+
+        H0_early = model.get_H0_early(samples).numpy()
+        H0_late = model.get_H0_late(samples).numpy()
+
+        # Plot main H0 distribution
+        ax.hist(H0_late, bins=50, density=True, alpha=0.5,
+               color=color, label=f"{name} (late)")
+
+        # If different, plot early too
+        if not np.allclose(H0_early, H0_late):
+            ax.hist(H0_early, bins=50, density=True, alpha=0.3,
+                   color=color, linestyle='--', label=f"{name} (early)")
+
+    # Add reference lines
+    if reference_values:
+        for ref_name, ref_val in reference_values.items():
+            ax.axvline(ref_val, linestyle='--', linewidth=2,
+                      label=f'{ref_name}: {ref_val}')
+
+    ax.set_xlabel("H₀ (km/s/Mpc)", fontsize=14)
+    ax.set_ylabel("Probability Density", fontsize=14)
+    ax.set_title("H₀ Posterior Distributions", fontsize=16)
+    ax.legend(fontsize=10)
+    ax.grid(True, alpha=0.3)
+
+    plt.tight_layout()
+
+    if output_path:
+        fig.savefig(output_path, dpi=150, bbox_inches='tight')
+        logger.info(f"Saved H0 posteriors to {output_path}")
+
+    return fig
+
+
+def plot_delta_H0_distribution(
+    theta_samples,
+    model: CosmologicalModel,
+    epsilon: float = 1.0,
+    output_path: Optional[Path] = None,
+) -> Any:
+    """
+    Plot the distribution of ΔH₀ = H₀_late - H₀_early.
+
+    Parameters
+    ----------
+    theta_samples : torch.Tensor
+        Posterior samples
+    model : CosmologicalModel
+        Model (must have different H0_early and H0_late)
+    epsilon : float
+        Resolution threshold to mark
+    output_path : Path, optional
+        Where to save
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+    """
+    plt = _get_plt()
+
+    if hasattr(theta_samples, 'cpu'):
+        theta_samples = theta_samples.cpu()
+
+    H0_early = model.get_H0_early(theta_samples).numpy()
+    H0_late = model.get_H0_late(theta_samples).numpy()
+    delta_H0 = H0_late - H0_early
+
+    fig, ax = plt.subplots(figsize=(10, 6))
+
+    # Histogram
+    n, bins, patches = ax.hist(delta_H0, bins=100, density=True, alpha=0.7)
+
+    # Color by resolution
+    for patch, left, right in zip(patches, bins[:-1], bins[1:]):
+        if abs((left + right) / 2) < epsilon:
+            patch.set_facecolor('green')
+            patch.set_alpha(0.8)
+        else:
+            patch.set_facecolor('red')
+            patch.set_alpha(0.5)
+
+    # Resolution zone
+    ax.axvspan(-epsilon, epsilon, alpha=0.2, color='green', label=f'|ΔH₀| < {epsilon}')
+    ax.axvline(0, color='black', linestyle='-', linewidth=2)
+
+    # Statistics
+    mean_delta = np.mean(delta_H0)
+    std_delta = np.std(delta_H0)
+    prob_res = np.mean(np.abs(delta_H0) < epsilon)
+
+    ax.axvline(mean_delta, color='blue', linestyle='--', label=f'Mean: {mean_delta:.2f}')
+
+    textstr = f'ΔH₀ = {mean_delta:.2f} ± {std_delta:.2f}\nP(resolution) = {prob_res:.1%}'
+    props = dict(boxstyle='round', facecolor='wheat', alpha=0.8)
+    ax.text(0.95, 0.95, textstr, transform=ax.transAxes, fontsize=12,
+           verticalalignment='top', horizontalalignment='right', bbox=props)
+
+    ax.set_xlabel("ΔH₀ = H₀(late) - H₀(early) (km/s/Mpc)", fontsize=14)
+    ax.set_ylabel("Probability Density", fontsize=14)
+    ax.set_title("Hubble Tension: ΔH₀ Distribution", fontsize=16)
+    ax.legend(fontsize=12)
+    ax.grid(True, alpha=0.3)
+
+    plt.tight_layout()
+
+    if output_path:
+        fig.savefig(output_path, dpi=150, bbox_inches='tight')
+        logger.info(f"Saved delta H0 distribution to {output_path}")
+
+    return fig

--- a/cosmology/__init__.py
+++ b/cosmology/__init__.py
@@ -1,0 +1,35 @@
+"""
+cosmology/__init__.py
+---------------------
+Cosmological models for Hubble inference.
+"""
+
+from cosmology.base import CosmologicalModel
+from cosmology.concordance import ConcordanceModel
+from cosmology.discordance import DiscordanceModel
+from cosmology.wcdm import WCDMModel
+from cosmology.early_de import EarlyDarkEnergyModel
+
+__all__ = [
+    "CosmologicalModel",
+    "ConcordanceModel",
+    "DiscordanceModel",
+    "WCDMModel",
+    "EarlyDarkEnergyModel",
+]
+
+# Model registry for CLI access
+MODELS = {
+    "concordance": ConcordanceModel,
+    "discordance": DiscordanceModel,
+    "wcdm": WCDMModel,
+    "early_de": EarlyDarkEnergyModel,
+}
+
+
+def get_model(name: str) -> CosmologicalModel:
+    """Get a model instance by name."""
+    if name not in MODELS:
+        available = ", ".join(MODELS.keys())
+        raise ValueError(f"Unknown model '{name}'. Available: {available}")
+    return MODELS[name]()

--- a/cosmology/base.py
+++ b/cosmology/base.py
@@ -1,0 +1,282 @@
+"""
+cosmology/base.py
+-----------------
+Base class for cosmological models.
+
+Each model defines:
+- Parameter space (names, bounds, priors)
+- Forward model (θ → x)
+- How H₀ is interpreted for early vs late universe
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import List, Dict, Callable, Optional, Tuple
+import torch
+import numpy as np
+
+from config import DEVICE, logger
+
+
+@dataclass
+class Parameter:
+    """Definition of a single model parameter."""
+    name: str
+    symbol: str
+    min_val: float
+    max_val: float
+    prior_type: str = "uniform"  # "uniform", "gaussian", "log_uniform"
+    prior_mean: Optional[float] = None
+    prior_std: Optional[float] = None
+    description: str = ""
+
+    def sample_prior(self, n_samples: int, device: torch.device = DEVICE) -> torch.Tensor:
+        """Draw samples from the prior distribution."""
+        if self.prior_type == "uniform":
+            return torch.rand(n_samples, device=device) * (self.max_val - self.min_val) + self.min_val
+        elif self.prior_type == "gaussian":
+            samples = torch.randn(n_samples, device=device) * self.prior_std + self.prior_mean
+            # Truncate to bounds
+            samples = torch.clamp(samples, self.min_val, self.max_val)
+            return samples
+        elif self.prior_type == "log_uniform":
+            log_min, log_max = np.log(self.min_val), np.log(self.max_val)
+            log_samples = torch.rand(n_samples, device=device) * (log_max - log_min) + log_min
+            return torch.exp(log_samples)
+        else:
+            raise ValueError(f"Unknown prior type: {self.prior_type}")
+
+    def log_prior(self, values: torch.Tensor) -> torch.Tensor:
+        """Compute log prior probability."""
+        # Check bounds
+        in_bounds = (values >= self.min_val) & (values <= self.max_val)
+
+        if self.prior_type == "uniform":
+            log_p = torch.where(
+                in_bounds,
+                torch.tensor(-np.log(self.max_val - self.min_val), device=values.device),
+                torch.tensor(-np.inf, device=values.device)
+            )
+        elif self.prior_type == "gaussian":
+            log_p = -0.5 * ((values - self.prior_mean) / self.prior_std) ** 2
+            log_p = log_p - np.log(self.prior_std) - 0.5 * np.log(2 * np.pi)
+            log_p = torch.where(in_bounds, log_p, torch.tensor(-np.inf, device=values.device))
+        elif self.prior_type == "log_uniform":
+            log_p = torch.where(
+                in_bounds,
+                -torch.log(values) - np.log(np.log(self.max_val / self.min_val)),
+                torch.tensor(-np.inf, device=values.device)
+            )
+        else:
+            raise ValueError(f"Unknown prior type: {self.prior_type}")
+
+        return log_p
+
+
+class CosmologicalModel(ABC):
+    """
+    Abstract base class for cosmological models.
+
+    Each model defines a specific parameterization of the universe
+    and how observational data maps to those parameters.
+    """
+
+    def __init__(self):
+        self._parameters: List[Parameter] = []
+        self._setup_parameters()
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Human-readable model name."""
+        pass
+
+    @property
+    @abstractmethod
+    def short_name(self) -> str:
+        """Short identifier for files/CLI."""
+        pass
+
+    @property
+    def description(self) -> str:
+        """Detailed model description."""
+        return ""
+
+    @abstractmethod
+    def _setup_parameters(self) -> None:
+        """Define model parameters. Called in __init__."""
+        pass
+
+    @property
+    def parameters(self) -> List[Parameter]:
+        """List of model parameters."""
+        return self._parameters
+
+    @property
+    def n_params(self) -> int:
+        """Number of parameters."""
+        return len(self._parameters)
+
+    @property
+    def param_names(self) -> List[str]:
+        """List of parameter names."""
+        return [p.name for p in self._parameters]
+
+    @property
+    def param_symbols(self) -> List[str]:
+        """List of parameter symbols (for plotting)."""
+        return [p.symbol for p in self._parameters]
+
+    @property
+    def theta_min(self) -> torch.Tensor:
+        """Minimum bounds for all parameters."""
+        return torch.tensor([p.min_val for p in self._parameters], device=DEVICE)
+
+    @property
+    def theta_max(self) -> torch.Tensor:
+        """Maximum bounds for all parameters."""
+        return torch.tensor([p.max_val for p in self._parameters], device=DEVICE)
+
+    def add_parameter(self, param: Parameter) -> None:
+        """Add a parameter to the model."""
+        self._parameters.append(param)
+
+    def sample_prior(self, n_samples: int) -> torch.Tensor:
+        """
+        Draw samples from the joint prior distribution.
+
+        Returns
+        -------
+        torch.Tensor
+            Shape (n_samples, n_params)
+        """
+        samples = torch.stack([
+            p.sample_prior(n_samples) for p in self._parameters
+        ], dim=1)
+        return samples
+
+    def log_prior(self, theta: torch.Tensor) -> torch.Tensor:
+        """
+        Compute log prior probability for parameter vectors.
+
+        Parameters
+        ----------
+        theta : torch.Tensor
+            Shape (n_samples, n_params) or (n_params,)
+
+        Returns
+        -------
+        torch.Tensor
+            Log prior probability for each sample
+        """
+        if theta.dim() == 1:
+            theta = theta.unsqueeze(0)
+
+        log_p = torch.zeros(theta.shape[0], device=theta.device)
+        for i, param in enumerate(self._parameters):
+            log_p = log_p + param.log_prior(theta[:, i])
+
+        return log_p
+
+    @abstractmethod
+    def get_H0_early(self, theta: torch.Tensor) -> torch.Tensor:
+        """
+        Extract the early-universe Hubble constant from parameters.
+
+        This is H₀ as inferred from CMB/BAO (sound horizon calibration).
+
+        Parameters
+        ----------
+        theta : torch.Tensor
+            Parameter vector(s)
+
+        Returns
+        -------
+        torch.Tensor
+            H₀ values for early universe
+        """
+        pass
+
+    @abstractmethod
+    def get_H0_late(self, theta: torch.Tensor) -> torch.Tensor:
+        """
+        Extract the late-universe Hubble constant from parameters.
+
+        This is H₀ as inferred from local distance ladder (Cepheids, SNe).
+
+        Parameters
+        ----------
+        theta : torch.Tensor
+            Parameter vector(s)
+
+        Returns
+        -------
+        torch.Tensor
+            H₀ values for late universe
+        """
+        pass
+
+    @abstractmethod
+    def get_cosmology_params(self, theta: torch.Tensor) -> Dict[str, torch.Tensor]:
+        """
+        Convert parameter vector to dictionary of cosmological parameters.
+
+        Returns standardized parameters for forward model:
+        - H0_early, H0_late (may be same or different)
+        - Om (matter density)
+        - Ode (dark energy density)
+        - w0 (DE equation of state)
+        - wa (DE evolution)
+        - Any model-specific parameters
+
+        Parameters
+        ----------
+        theta : torch.Tensor
+            Parameter vector
+
+        Returns
+        -------
+        dict
+            Dictionary of cosmological parameters
+        """
+        pass
+
+    def summary_vector(self, theta: torch.Tensor, obs: dict) -> torch.Tensor:
+        """
+        Compute summary statistics for given parameters.
+
+        This wraps the forward model with model-specific parameter mapping.
+
+        Parameters
+        ----------
+        theta : torch.Tensor
+            Model parameters
+        obs : dict
+            Observation data
+
+        Returns
+        -------
+        torch.Tensor
+            Summary statistics vector
+        """
+        from forward import summary_vector as fwd_summary
+
+        # Get cosmological parameters for this model
+        cosmo = self.get_cosmology_params(theta)
+
+        # Build standard theta vector for forward model
+        # Forward model expects: (H0, Om, Ode, w0, wa)
+        # Use H0_late for distance calculations (local calibration)
+        theta_fwd = torch.stack([
+            cosmo["H0_late"],
+            cosmo["Om"],
+            cosmo["Ode"],
+            cosmo["w0"],
+            cosmo["wa"]
+        ])
+
+        return fwd_summary(theta_fwd, obs)
+
+    def __repr__(self) -> str:
+        params_str = ", ".join([f"{p.symbol}" for p in self._parameters])
+        return f"{self.name}({params_str})"

--- a/cosmology/concordance.py
+++ b/cosmology/concordance.py
@@ -1,0 +1,126 @@
+"""
+cosmology/concordance.py
+------------------------
+Standard ΛCDM concordance model.
+
+This is the baseline model where a single H₀ applies to both
+early and late universe measurements. Any tension between
+datasets must be explained by statistical fluctuation or
+systematic errors, not new physics.
+
+Parameters: θ = (H₀, Ωm, Ωde, w₀, wa)
+"""
+
+import torch
+from typing import Dict
+
+from cosmology.base import CosmologicalModel, Parameter
+
+
+class ConcordanceModel(CosmologicalModel):
+    """
+    Standard ΛCDM/wCDM concordance cosmology.
+
+    Single Hubble constant for all epochs. This is the null hypothesis
+    against which tension is measured.
+    """
+
+    @property
+    def name(self) -> str:
+        return "ΛCDM Concordance"
+
+    @property
+    def short_name(self) -> str:
+        return "concordance"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Standard cosmological model with a single Hubble constant. "
+            "Early and late universe measurements should agree if this model is correct. "
+            "Includes dynamic dark energy parameters (w₀, wa) but assumes no H₀ split."
+        )
+
+    def _setup_parameters(self) -> None:
+        """Define the 5 concordance parameters."""
+        self.add_parameter(Parameter(
+            name="H0",
+            symbol="H₀",
+            min_val=50.0,
+            max_val=90.0,
+            prior_type="uniform",
+            description="Hubble constant [km/s/Mpc]"
+        ))
+
+        self.add_parameter(Parameter(
+            name="Om",
+            symbol="Ωm",
+            min_val=0.20,
+            max_val=0.45,
+            prior_type="uniform",
+            description="Matter density parameter"
+        ))
+
+        self.add_parameter(Parameter(
+            name="Ode",
+            symbol="Ωde",
+            min_val=0.55,
+            max_val=0.80,
+            prior_type="uniform",
+            description="Dark energy density parameter"
+        ))
+
+        self.add_parameter(Parameter(
+            name="w0",
+            symbol="w₀",
+            min_val=-2.0,
+            max_val=-0.3,
+            prior_type="gaussian",
+            prior_mean=-1.0,
+            prior_std=0.3,
+            description="Dark energy equation of state (today)"
+        ))
+
+        self.add_parameter(Parameter(
+            name="wa",
+            symbol="wa",
+            min_val=-1.0,
+            max_val=1.0,
+            prior_type="gaussian",
+            prior_mean=0.0,
+            prior_std=0.5,
+            description="Dark energy equation of state evolution"
+        ))
+
+    def get_H0_early(self, theta: torch.Tensor) -> torch.Tensor:
+        """Early universe H₀ (same as late in concordance)."""
+        if theta.dim() == 1:
+            return theta[0]
+        return theta[:, 0]
+
+    def get_H0_late(self, theta: torch.Tensor) -> torch.Tensor:
+        """Late universe H₀ (same as early in concordance)."""
+        if theta.dim() == 1:
+            return theta[0]
+        return theta[:, 0]
+
+    def get_cosmology_params(self, theta: torch.Tensor) -> Dict[str, torch.Tensor]:
+        """Extract cosmological parameters from theta vector."""
+        if theta.dim() == 1:
+            return {
+                "H0_early": theta[0],
+                "H0_late": theta[0],  # Same!
+                "Om": theta[1],
+                "Ode": theta[2],
+                "w0": theta[3],
+                "wa": theta[4],
+            }
+        else:
+            return {
+                "H0_early": theta[:, 0],
+                "H0_late": theta[:, 0],  # Same!
+                "Om": theta[:, 1],
+                "Ode": theta[:, 2],
+                "w0": theta[:, 3],
+                "wa": theta[:, 4],
+            }

--- a/cosmology/discordance.py
+++ b/cosmology/discordance.py
@@ -1,0 +1,196 @@
+"""
+cosmology/discordance.py
+------------------------
+Discordance model with split Hubble constant.
+
+This model allows early-universe (CMB/BAO) and late-universe (SNe/Cepheids)
+measurements to have different effective Hubble constants. This could arise from:
+
+1. Unmodeled systematic errors in one or both measurement types
+2. New physics that modifies the distance-redshift relation differently
+   at early vs late times
+3. A fundamental breakdown of the standard cosmological model
+
+If this model is strongly preferred over concordance, the Hubble tension
+is "real" in a Bayesian sense.
+
+Parameters: θ = (H₀_early, H₀_late, Ωm, Ωde, w₀, wa)
+"""
+
+import torch
+from typing import Dict
+
+from cosmology.base import CosmologicalModel, Parameter
+
+
+class DiscordanceModel(CosmologicalModel):
+    """
+    Split-H₀ discordance model.
+
+    Allows different Hubble constants for early and late universe.
+    This is the alternative hypothesis for testing Hubble tension.
+    """
+
+    @property
+    def name(self) -> str:
+        return "Split-H₀ Discordance"
+
+    @property
+    def short_name(self) -> str:
+        return "discordance"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Extended model with separate Hubble constants for early (CMB/BAO) "
+            "and late (Cepheids/SNe) universe measurements. If the posterior "
+            "strongly prefers H₀_early ≠ H₀_late, the Hubble tension is real. "
+            "The probability P(|ΔH₀| < ε) quantifies resolution likelihood."
+        )
+
+    def _setup_parameters(self) -> None:
+        """Define the 6 discordance parameters."""
+        self.add_parameter(Parameter(
+            name="H0_early",
+            symbol="H₀ᵉᵃʳˡʸ",
+            min_val=50.0,
+            max_val=90.0,
+            prior_type="uniform",
+            description="Hubble constant from early universe (CMB/BAO) [km/s/Mpc]"
+        ))
+
+        self.add_parameter(Parameter(
+            name="H0_late",
+            symbol="H₀ˡᵃᵗᵉ",
+            min_val=50.0,
+            max_val=90.0,
+            prior_type="uniform",
+            description="Hubble constant from late universe (SNe/Cepheids) [km/s/Mpc]"
+        ))
+
+        self.add_parameter(Parameter(
+            name="Om",
+            symbol="Ωm",
+            min_val=0.20,
+            max_val=0.45,
+            prior_type="uniform",
+            description="Matter density parameter"
+        ))
+
+        self.add_parameter(Parameter(
+            name="Ode",
+            symbol="Ωde",
+            min_val=0.55,
+            max_val=0.80,
+            prior_type="uniform",
+            description="Dark energy density parameter"
+        ))
+
+        self.add_parameter(Parameter(
+            name="w0",
+            symbol="w₀",
+            min_val=-2.0,
+            max_val=-0.3,
+            prior_type="gaussian",
+            prior_mean=-1.0,
+            prior_std=0.3,
+            description="Dark energy equation of state (today)"
+        ))
+
+        self.add_parameter(Parameter(
+            name="wa",
+            symbol="wa",
+            min_val=-1.0,
+            max_val=1.0,
+            prior_type="gaussian",
+            prior_mean=0.0,
+            prior_std=0.5,
+            description="Dark energy equation of state evolution"
+        ))
+
+    def get_H0_early(self, theta: torch.Tensor) -> torch.Tensor:
+        """Early universe H₀ from CMB/BAO."""
+        if theta.dim() == 1:
+            return theta[0]
+        return theta[:, 0]
+
+    def get_H0_late(self, theta: torch.Tensor) -> torch.Tensor:
+        """Late universe H₀ from local distance ladder."""
+        if theta.dim() == 1:
+            return theta[1]
+        return theta[:, 1]
+
+    def get_cosmology_params(self, theta: torch.Tensor) -> Dict[str, torch.Tensor]:
+        """Extract cosmological parameters from theta vector."""
+        if theta.dim() == 1:
+            return {
+                "H0_early": theta[0],
+                "H0_late": theta[1],  # Different!
+                "Om": theta[2],
+                "Ode": theta[3],
+                "w0": theta[4],
+                "wa": theta[5],
+            }
+        else:
+            return {
+                "H0_early": theta[:, 0],
+                "H0_late": theta[:, 1],  # Different!
+                "Om": theta[:, 2],
+                "Ode": theta[:, 3],
+                "w0": theta[:, 4],
+                "wa": theta[:, 5],
+            }
+
+    def compute_delta_H0(self, theta: torch.Tensor) -> torch.Tensor:
+        """
+        Compute the H₀ difference (tension magnitude).
+
+        Parameters
+        ----------
+        theta : torch.Tensor
+            Parameter samples
+
+        Returns
+        -------
+        torch.Tensor
+            |H₀_late - H₀_early| for each sample
+        """
+        H0_early = self.get_H0_early(theta)
+        H0_late = self.get_H0_late(theta)
+        return torch.abs(H0_late - H0_early)
+
+    def probability_resolution(
+        self,
+        theta_samples: torch.Tensor,
+        epsilon: float = 1.0
+    ) -> tuple:
+        """
+        Compute the probability that the tension is resolvable.
+
+        P(|H₀_late - H₀_early| < ε)
+
+        A low probability means the data strongly prefer different H₀ values,
+        indicating the tension is "real" and not a statistical fluctuation.
+
+        Parameters
+        ----------
+        theta_samples : torch.Tensor
+            Posterior samples from this model
+        epsilon : float
+            Tolerance in km/s/Mpc
+
+        Returns
+        -------
+        tuple
+            (probability, standard_error)
+        """
+        import numpy as np
+
+        delta_H0 = self.compute_delta_H0(theta_samples)
+        resolved = (delta_H0 < epsilon).float()
+
+        prob = resolved.mean().item()
+        n = len(resolved)
+        std_err = np.sqrt(prob * (1 - prob) / n)
+
+        return prob, std_err

--- a/cosmology/early_de.py
+++ b/cosmology/early_de.py
@@ -1,0 +1,228 @@
+"""
+cosmology/early_de.py
+---------------------
+Early Dark Energy (EDE) model.
+
+This model adds a component of dark energy that was significant
+at early times (around recombination) but dilutes away by today.
+EDE is one of the leading theoretical proposals for resolving
+the Hubble tension.
+
+The mechanism: EDE reduces the sound horizon at recombination,
+which means a higher H₀ is needed to match CMB observations.
+This can bring early-universe H₀ into agreement with local measurements.
+
+Parameters: θ = (H₀, Ωm, Ωde, w₀, wa, f_ede, z_c)
+"""
+
+import torch
+from typing import Dict
+
+from cosmology.base import CosmologicalModel, Parameter
+
+
+class EarlyDarkEnergyModel(CosmologicalModel):
+    """
+    Early Dark Energy (EDE) model.
+
+    Adds a transient dark energy component at early times that
+    could resolve the Hubble tension by reducing the sound horizon.
+    """
+
+    @property
+    def name(self) -> str:
+        return "Early Dark Energy"
+
+    @property
+    def short_name(self) -> str:
+        return "early_de"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Cosmology with an early dark energy component that contributes "
+            "significantly around recombination (z ~ 3000-5000) but dilutes away "
+            "by today. This reduces the sound horizon, increasing the H₀ inferred "
+            "from CMB data. A leading candidate for resolving the Hubble tension."
+        )
+
+    def _setup_parameters(self) -> None:
+        """Define the 7 EDE parameters."""
+        self.add_parameter(Parameter(
+            name="H0",
+            symbol="H₀",
+            min_val=60.0,
+            max_val=85.0,
+            prior_type="uniform",
+            description="Hubble constant [km/s/Mpc]"
+        ))
+
+        self.add_parameter(Parameter(
+            name="Om",
+            symbol="Ωm",
+            min_val=0.25,
+            max_val=0.40,
+            prior_type="uniform",
+            description="Matter density parameter (today)"
+        ))
+
+        self.add_parameter(Parameter(
+            name="Ode",
+            symbol="Ωde",
+            min_val=0.60,
+            max_val=0.75,
+            prior_type="uniform",
+            description="Late dark energy density parameter"
+        ))
+
+        self.add_parameter(Parameter(
+            name="w0",
+            symbol="w₀",
+            min_val=-1.5,
+            max_val=-0.5,
+            prior_type="gaussian",
+            prior_mean=-1.0,
+            prior_std=0.2,
+            description="Late DE equation of state"
+        ))
+
+        self.add_parameter(Parameter(
+            name="wa",
+            symbol="wa",
+            min_val=-0.5,
+            max_val=0.5,
+            prior_type="gaussian",
+            prior_mean=0.0,
+            prior_std=0.2,
+            description="Late DE evolution"
+        ))
+
+        # EDE-specific parameters
+        self.add_parameter(Parameter(
+            name="f_ede",
+            symbol="fₑᵈₑ",
+            min_val=0.0,
+            max_val=0.2,
+            prior_type="uniform",
+            description="Maximum EDE fraction (at z_c)"
+        ))
+
+        self.add_parameter(Parameter(
+            name="log10_z_c",
+            symbol="log₁₀(zc)",
+            min_val=3.0,
+            max_val=4.5,
+            prior_type="uniform",
+            description="Log10 of critical redshift for EDE"
+        ))
+
+    def get_H0_early(self, theta: torch.Tensor) -> torch.Tensor:
+        """
+        Effective early universe H₀.
+
+        In EDE, the "early" H₀ is modified by the EDE contribution.
+        The sound horizon is smaller, so the inferred H₀ is higher.
+        """
+        if theta.dim() == 1:
+            H0 = theta[0]
+            f_ede = theta[5]
+        else:
+            H0 = theta[:, 0]
+            f_ede = theta[:, 5]
+
+        # Approximate correction: H0_eff ≈ H0 * (1 + α * f_ede)
+        # where α ~ 3-4 captures the sound horizon reduction
+        # This is a simplified approximation; full calculation requires
+        # solving the Friedmann equations with EDE component
+        alpha = 3.5
+        return H0 * (1 + alpha * f_ede)
+
+    def get_H0_late(self, theta: torch.Tensor) -> torch.Tensor:
+        """
+        Late universe H₀.
+
+        By today, EDE has diluted away, so local H₀ is the bare value.
+        """
+        if theta.dim() == 1:
+            return theta[0]
+        return theta[:, 0]
+
+    def get_cosmology_params(self, theta: torch.Tensor) -> Dict[str, torch.Tensor]:
+        """Extract all cosmological parameters."""
+        if theta.dim() == 1:
+            return {
+                "H0_early": self.get_H0_early(theta),
+                "H0_late": self.get_H0_late(theta),
+                "Om": theta[1],
+                "Ode": theta[2],
+                "w0": theta[3],
+                "wa": theta[4],
+                "f_ede": theta[5],
+                "z_c": 10 ** theta[6],  # Convert from log10
+            }
+        else:
+            return {
+                "H0_early": self.get_H0_early(theta),
+                "H0_late": self.get_H0_late(theta),
+                "Om": theta[:, 1],
+                "Ode": theta[:, 2],
+                "w0": theta[:, 3],
+                "wa": theta[:, 4],
+                "f_ede": theta[:, 5],
+                "z_c": 10 ** theta[:, 6],
+            }
+
+    def ede_fraction(self, z: torch.Tensor, theta: torch.Tensor) -> torch.Tensor:
+        """
+        Compute EDE energy density fraction at redshift z.
+
+        Uses a simplified model where EDE peaks at z_c and falls off
+        as a power law on either side.
+
+        Parameters
+        ----------
+        z : torch.Tensor
+            Redshift values
+        theta : torch.Tensor
+            Model parameters
+
+        Returns
+        -------
+        torch.Tensor
+            EDE fraction Ω_ede(z)
+        """
+        if theta.dim() == 1:
+            f_ede = theta[5]
+            z_c = 10 ** theta[6]
+        else:
+            f_ede = theta[:, 5].unsqueeze(-1)
+            z_c = (10 ** theta[:, 6]).unsqueeze(-1)
+
+        # Simplified EDE profile: peaks at z_c, width ~ z_c
+        # Full model would use axion-like potential
+        x = z / z_c
+        profile = 1.0 / (1.0 + (x - 1) ** 2)
+
+        return f_ede * profile
+
+    def resolves_tension(self, theta: torch.Tensor, tolerance: float = 2.0) -> torch.Tensor:
+        """
+        Check if this parameter configuration resolves the tension.
+
+        Tension is "resolved" if early and late H₀ agree within tolerance.
+
+        Parameters
+        ----------
+        theta : torch.Tensor
+            Model parameters
+        tolerance : float
+            Allowed difference in km/s/Mpc
+
+        Returns
+        -------
+        torch.Tensor
+            Boolean tensor indicating resolution
+        """
+        H0_early = self.get_H0_early(theta)
+        H0_late = self.get_H0_late(theta)
+        return torch.abs(H0_early - H0_late) < tolerance

--- a/cosmology/wcdm.py
+++ b/cosmology/wcdm.py
@@ -1,0 +1,152 @@
+"""
+cosmology/wcdm.py
+-----------------
+Dynamic dark energy model (w₀-wa parameterization).
+
+This is similar to concordance but with stronger emphasis on
+the dark energy parameters as potential resolution mechanisms
+for the Hubble tension.
+
+The idea: if w₀ ≠ -1 or wa ≠ 0, the expansion history differs
+from ΛCDM, which could reconcile early and late H₀ measurements.
+
+Parameters: θ = (H₀, Ωm, Ωde, w₀, wa)
+"""
+
+import torch
+from typing import Dict
+
+from cosmology.base import CosmologicalModel, Parameter
+
+
+class WCDMModel(CosmologicalModel):
+    """
+    Dynamic dark energy (w₀-wa) model.
+
+    Same parameterization as concordance but with wider priors
+    on dark energy parameters to explore tension resolution.
+    """
+
+    @property
+    def name(self) -> str:
+        return "Dynamic Dark Energy (w₀-wa)"
+
+    @property
+    def short_name(self) -> str:
+        return "wcdm"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Cosmology with dynamic dark energy equation of state w(a) = w₀ + wa(1-a). "
+            "Deviations from w₀=-1, wa=0 (cosmological constant) could potentially "
+            "resolve the Hubble tension by modifying the expansion history."
+        )
+
+    def _setup_parameters(self) -> None:
+        """Define parameters with wider DE priors."""
+        self.add_parameter(Parameter(
+            name="H0",
+            symbol="H₀",
+            min_val=50.0,
+            max_val=90.0,
+            prior_type="uniform",
+            description="Hubble constant [km/s/Mpc]"
+        ))
+
+        self.add_parameter(Parameter(
+            name="Om",
+            symbol="Ωm",
+            min_val=0.15,
+            max_val=0.50,
+            prior_type="uniform",
+            description="Matter density parameter"
+        ))
+
+        self.add_parameter(Parameter(
+            name="Ode",
+            symbol="Ωde",
+            min_val=0.50,
+            max_val=0.85,
+            prior_type="uniform",
+            description="Dark energy density parameter"
+        ))
+
+        # Wider priors on DE parameters
+        self.add_parameter(Parameter(
+            name="w0",
+            symbol="w₀",
+            min_val=-3.0,
+            max_val=0.0,
+            prior_type="uniform",  # Flat prior to explore full range
+            description="Dark energy equation of state (today)"
+        ))
+
+        self.add_parameter(Parameter(
+            name="wa",
+            symbol="wa",
+            min_val=-2.0,
+            max_val=2.0,
+            prior_type="uniform",  # Flat prior to explore full range
+            description="Dark energy equation of state evolution"
+        ))
+
+    def get_H0_early(self, theta: torch.Tensor) -> torch.Tensor:
+        """Early universe H₀."""
+        if theta.dim() == 1:
+            return theta[0]
+        return theta[:, 0]
+
+    def get_H0_late(self, theta: torch.Tensor) -> torch.Tensor:
+        """Late universe H₀ (same as early in this model)."""
+        if theta.dim() == 1:
+            return theta[0]
+        return theta[:, 0]
+
+    def get_cosmology_params(self, theta: torch.Tensor) -> Dict[str, torch.Tensor]:
+        """Extract cosmological parameters."""
+        if theta.dim() == 1:
+            return {
+                "H0_early": theta[0],
+                "H0_late": theta[0],
+                "Om": theta[1],
+                "Ode": theta[2],
+                "w0": theta[3],
+                "wa": theta[4],
+            }
+        else:
+            return {
+                "H0_early": theta[:, 0],
+                "H0_late": theta[:, 0],
+                "Om": theta[:, 1],
+                "Ode": theta[:, 2],
+                "w0": theta[:, 3],
+                "wa": theta[:, 4],
+            }
+
+    def is_phantom(self, theta: torch.Tensor) -> torch.Tensor:
+        """
+        Check if dark energy is phantom (w < -1).
+
+        Phantom dark energy has exotic properties (negative kinetic energy)
+        but could help resolve Hubble tension.
+        """
+        if theta.dim() == 1:
+            w0 = theta[3]
+        else:
+            w0 = theta[:, 3]
+        return w0 < -1.0
+
+    def compute_w_at_z(self, theta: torch.Tensor, z: float) -> torch.Tensor:
+        """
+        Compute equation of state at redshift z.
+
+        w(z) = w₀ + wa * z / (1 + z)
+        """
+        if theta.dim() == 1:
+            w0, wa = theta[3], theta[4]
+        else:
+            w0, wa = theta[:, 3], theta[:, 4]
+
+        a = 1.0 / (1.0 + z)
+        return w0 + wa * (1.0 - a)

--- a/inference/__init__.py
+++ b/inference/__init__.py
@@ -1,0 +1,16 @@
+"""
+inference/__init__.py
+---------------------
+Inference modules for Hubble.
+"""
+
+from inference.evidence import estimate_log_evidence, compute_evidence_ratio
+from inference.tension import TensionAnalyzer
+from inference.comparison import ModelComparison
+
+__all__ = [
+    "estimate_log_evidence",
+    "compute_evidence_ratio",
+    "TensionAnalyzer",
+    "ModelComparison",
+]

--- a/inference/comparison.py
+++ b/inference/comparison.py
@@ -1,0 +1,359 @@
+"""
+inference/comparison.py
+-----------------------
+Bayesian model comparison for cosmological models.
+
+This module orchestrates the comparison of multiple cosmological models
+to determine which best explains the data. The key outputs are:
+
+1. Bayes factors between model pairs
+2. Posterior model probabilities
+3. Ranking of models by evidence
+4. Tension resolution probability under each model
+"""
+
+import torch
+import numpy as np
+from typing import Dict, List, Optional, Any
+from dataclasses import dataclass, field
+from pathlib import Path
+import json
+
+from config import DEVICE, paths, logger
+from cosmology.base import CosmologicalModel
+from inference.evidence import estimate_log_evidence, EvidenceResult
+from inference.tension import TensionAnalyzer, TensionResult
+
+
+@dataclass
+class ModelResult:
+    """Results for a single model."""
+    model: CosmologicalModel
+    evidence: EvidenceResult
+    tension: Optional[TensionResult] = None
+    posterior_samples: Optional[torch.Tensor] = None
+    flow_path: Optional[Path] = None
+
+    @property
+    def log_evidence(self) -> float:
+        return self.evidence.log_evidence
+
+    def to_dict(self) -> Dict:
+        """Convert to serializable dictionary."""
+        d = {
+            "model_name": self.model.name,
+            "model_short_name": self.model.short_name,
+            "n_params": self.model.n_params,
+            "log_evidence": self.evidence.log_evidence,
+            "log_evidence_std": self.evidence.log_evidence_std,
+            "effective_sample_size": self.evidence.effective_sample_size,
+        }
+        if self.tension:
+            d["tension"] = {
+                "prob_resolution": self.tension.prob_resolution,
+                "prob_resolution_std": self.tension.prob_resolution_std,
+                "epsilon": self.tension.epsilon,
+                "delta_H0_mean": self.tension.delta_H0_mean,
+                "delta_H0_std": self.tension.delta_H0_std,
+                "sigma_tension": self.tension.sigma_tension,
+            }
+        return d
+
+
+@dataclass
+class ComparisonResult:
+    """Results from comparing multiple models."""
+    models: List[ModelResult]
+    bayes_factors: Dict[str, Dict[str, float]] = field(default_factory=dict)
+    model_probabilities: Dict[str, float] = field(default_factory=dict)
+    ranking: List[str] = field(default_factory=list)
+    best_model: str = ""
+
+    def __repr__(self) -> str:
+        lines = ["=" * 60, "Model Comparison Results", "=" * 60, ""]
+
+        lines.append("Model Evidence:")
+        for mr in sorted(self.models, key=lambda x: -x.log_evidence):
+            lines.append(f"  {mr.model.short_name:15s}: log(Z) = {mr.log_evidence:8.2f}")
+
+        lines.append("")
+        lines.append("Model Probabilities (assuming equal priors):")
+        for name, prob in sorted(self.model_probabilities.items(), key=lambda x: -x[1]):
+            lines.append(f"  {name:15s}: {prob:6.1%}")
+
+        lines.append("")
+        lines.append(f"Best model: {self.best_model}")
+
+        if self.bayes_factors:
+            lines.append("")
+            lines.append("Bayes Factors (row/column):")
+            names = list(self.bayes_factors.keys())
+            header = "                " + "  ".join(f"{n:12s}" for n in names)
+            lines.append(header)
+            for n1 in names:
+                row = f"  {n1:12s}"
+                for n2 in names:
+                    if n1 == n2:
+                        row += f"  {'---':>12s}"
+                    else:
+                        bf = self.bayes_factors.get(n1, {}).get(n2, np.nan)
+                        if np.isfinite(bf):
+                            row += f"  {bf:12.2e}"
+                        else:
+                            row += f"  {'---':>12s}"
+                lines.append(row)
+
+        return "\n".join(lines)
+
+    def to_dict(self) -> Dict:
+        """Convert to serializable dictionary."""
+        return {
+            "models": [m.to_dict() for m in self.models],
+            "bayes_factors": self.bayes_factors,
+            "model_probabilities": self.model_probabilities,
+            "ranking": self.ranking,
+            "best_model": self.best_model,
+        }
+
+    def save(self, path: Path) -> None:
+        """Save results to JSON."""
+        with open(path, "w") as f:
+            json.dump(self.to_dict(), f, indent=2)
+        logger.info(f"Saved comparison results to {path}")
+
+
+class ModelComparison:
+    """
+    Compare multiple cosmological models using Bayesian evidence.
+
+    Example usage:
+    ```
+    comparison = ModelComparison()
+    comparison.add_model("concordance", flow_concordance, model_concordance)
+    comparison.add_model("discordance", flow_discordance, model_discordance)
+    results = comparison.compare(x_obs)
+    print(results)
+    ```
+    """
+
+    def __init__(self):
+        self.models: Dict[str, CosmologicalModel] = {}
+        self.flows: Dict[str, Any] = {}
+        self._results: Optional[ComparisonResult] = None
+
+    def add_model(
+        self,
+        name: str,
+        flow,
+        model: CosmologicalModel,
+    ) -> None:
+        """
+        Add a model to the comparison.
+
+        Parameters
+        ----------
+        name : str
+            Identifier for this model
+        flow : Flow
+            Trained normalizing flow
+        model : CosmologicalModel
+            Model definition
+        """
+        self.models[name] = model
+        self.flows[name] = flow
+        logger.info(f"Added model '{name}' ({model.name}, {model.n_params} params)")
+
+    def compare(
+        self,
+        x_obs: torch.Tensor,
+        n_samples: int = 50000,
+        n_posterior_samples: int = 100000,
+        epsilon: float = 1.0,
+    ) -> ComparisonResult:
+        """
+        Compare all registered models.
+
+        Parameters
+        ----------
+        x_obs : torch.Tensor
+            Observed summary statistics
+        n_samples : int
+            Samples for evidence estimation
+        n_posterior_samples : int
+            Samples for posterior/tension analysis
+        epsilon : float
+            Tolerance for tension resolution
+
+        Returns
+        -------
+        ComparisonResult
+            Full comparison results
+        """
+        logger.info("=" * 60)
+        logger.info("Starting Bayesian Model Comparison")
+        logger.info("=" * 60)
+
+        if len(self.models) < 2:
+            raise ValueError("Need at least 2 models for comparison")
+
+        model_results = []
+
+        # Compute evidence and tension for each model
+        for name, model in self.models.items():
+            logger.info(f"\nAnalyzing: {name}")
+            flow = self.flows[name]
+
+            # Evidence
+            evidence = estimate_log_evidence(flow, model, x_obs, n_samples)
+
+            # Posterior samples
+            flow.eval()
+            with torch.no_grad():
+                x_exp = x_obs.unsqueeze(0).expand(n_posterior_samples, -1) if x_obs.dim() == 1 \
+                    else x_obs.expand(n_posterior_samples, -1)
+                theta_post = flow.sample(n_posterior_samples, context=x_exp)
+                if isinstance(theta_post, tuple):
+                    theta_post = theta_post[0]
+
+            # Tension analysis
+            analyzer = TensionAnalyzer(model)
+            tension = analyzer.analyze(theta_post, epsilon=epsilon)
+
+            model_results.append(ModelResult(
+                model=model,
+                evidence=evidence,
+                tension=tension,
+                posterior_samples=theta_post,
+            ))
+
+        # Compute Bayes factors
+        bayes_factors = {}
+        for mr1 in model_results:
+            name1 = mr1.model.short_name
+            bayes_factors[name1] = {}
+            for mr2 in model_results:
+                name2 = mr2.model.short_name
+                if name1 != name2:
+                    log_bf = mr1.log_evidence - mr2.log_evidence
+                    bayes_factors[name1][name2] = np.exp(log_bf)
+
+        # Compute posterior model probabilities (equal prior)
+        log_evidences = np.array([mr.log_evidence for mr in model_results])
+        max_log_ev = log_evidences.max()
+        probs = np.exp(log_evidences - max_log_ev)
+        probs = probs / probs.sum()
+
+        model_probs = {
+            mr.model.short_name: p
+            for mr, p in zip(model_results, probs)
+        }
+
+        # Ranking
+        ranking = sorted(
+            [mr.model.short_name for mr in model_results],
+            key=lambda n: -model_probs[n]
+        )
+
+        self._results = ComparisonResult(
+            models=model_results,
+            bayes_factors=bayes_factors,
+            model_probabilities=model_probs,
+            ranking=ranking,
+            best_model=ranking[0],
+        )
+
+        logger.info(f"\n{self._results}")
+        return self._results
+
+    def get_tension_summary(self) -> str:
+        """
+        Get a human-readable summary of tension analysis.
+
+        Returns
+        -------
+        str
+            Summary text suitable for papers/reports
+        """
+        if self._results is None:
+            raise ValueError("Run compare() first")
+
+        lines = []
+        lines.append("Hubble Tension Analysis Summary")
+        lines.append("=" * 40)
+
+        for mr in self._results.models:
+            if mr.tension:
+                lines.append(f"\n{mr.model.name}:")
+                lines.append(f"  P(|ΔH₀| < {mr.tension.epsilon}) = "
+                           f"{mr.tension.prob_resolution:.3f} ± {mr.tension.prob_resolution_std:.3f}")
+                lines.append(f"  ΔH₀ = {mr.tension.delta_H0_mean:.2f} ± {mr.tension.delta_H0_std:.2f} km/s/Mpc")
+                lines.append(f"  Effective tension: {mr.tension.sigma_tension:.1f}σ")
+
+        # Key conclusions
+        best = self._results.best_model
+        best_prob = self._results.model_probabilities[best]
+
+        lines.append(f"\nConclusion:")
+        lines.append(f"  Best model: {best} (P = {best_prob:.1%})")
+
+        # Find discordance results if present
+        discord_mr = next(
+            (mr for mr in self._results.models if mr.model.short_name == "discordance"),
+            None
+        )
+        if discord_mr and discord_mr.tension:
+            prob_res = discord_mr.tension.prob_resolution
+            eps = discord_mr.tension.epsilon
+            lines.append(f"  Under split-H₀ model: {prob_res:.1%} probability of resolution "
+                        f"within {eps} km/s/Mpc")
+            if prob_res < 0.05:
+                lines.append("  → Strong evidence that Hubble tension is REAL")
+            elif prob_res < 0.32:
+                lines.append("  → Moderate evidence that Hubble tension is real")
+            else:
+                lines.append("  → Tension may be resolvable")
+
+        return "\n".join(lines)
+
+
+def quick_compare(
+    x_obs: torch.Tensor,
+    model_names: List[str] = ["concordance", "discordance"],
+    n_samples: int = 50000,
+) -> ComparisonResult:
+    """
+    Quick comparison of models using pre-trained flows.
+
+    Parameters
+    ----------
+    x_obs : torch.Tensor
+        Observed summary statistics
+    model_names : list
+        Names of models to compare
+    n_samples : int
+        Samples for evidence estimation
+
+    Returns
+    -------
+    ComparisonResult
+        Comparison results
+    """
+    from cosmology import get_model
+    from models import load_flow
+
+    comparison = ModelComparison()
+
+    for name in model_names:
+        model = get_model(name)
+        flow_path = paths.MODELS / f"flow_{name}.pt"
+
+        if not flow_path.exists():
+            raise FileNotFoundError(
+                f"No trained flow for '{name}'. "
+                f"Run 'hubble train --model {name}' first."
+            )
+
+        flow = load_flow(flow_path)
+        comparison.add_model(name, flow, model)
+
+    return comparison.compare(x_obs, n_samples=n_samples)

--- a/inference/evidence.py
+++ b/inference/evidence.py
@@ -1,0 +1,284 @@
+"""
+inference/evidence.py
+---------------------
+Bayesian evidence estimation using normalizing flows.
+
+The evidence (marginal likelihood) is:
+
+    P(x|M) = ∫ P(x|θ,M) P(θ|M) dθ
+
+This is the key quantity for Bayesian model comparison.
+We estimate it using importance sampling from the flow posterior.
+"""
+
+import torch
+import numpy as np
+from typing import Optional, Tuple, Dict
+from dataclasses import dataclass
+
+from config import DEVICE, logger
+from cosmology.base import CosmologicalModel
+
+
+@dataclass
+class EvidenceResult:
+    """Results from evidence estimation."""
+    log_evidence: float
+    log_evidence_std: float
+    effective_sample_size: float
+    n_samples: int
+    method: str
+
+    @property
+    def evidence(self) -> float:
+        """Evidence (not log)."""
+        return np.exp(self.log_evidence)
+
+    def __repr__(self) -> str:
+        return (
+            f"EvidenceResult(log_Z={self.log_evidence:.2f}±{self.log_evidence_std:.2f}, "
+            f"ESS={self.effective_sample_size:.0f}/{self.n_samples})"
+        )
+
+
+def estimate_log_evidence(
+    flow,
+    model: CosmologicalModel,
+    x_obs: torch.Tensor,
+    n_samples: int = 50000,
+    compute_likelihood_fn=None,
+) -> EvidenceResult:
+    """
+    Estimate log evidence using importance sampling.
+
+    The evidence is:
+        P(x) = ∫ P(x|θ) P(θ) dθ
+
+    We estimate this by importance sampling from the flow:
+        P(x) ≈ (1/N) Σ_i [P(x|θ_i) P(θ_i) / q(θ_i|x)]
+
+    where θ_i ~ q(θ|x) is the flow posterior.
+
+    Parameters
+    ----------
+    flow : Flow
+        Trained normalizing flow for this model
+    model : CosmologicalModel
+        The cosmological model
+    x_obs : torch.Tensor
+        Observed summary statistics
+    n_samples : int
+        Number of importance samples
+    compute_likelihood_fn : callable, optional
+        Function to compute log P(x|θ). If None, uses simple Gaussian.
+
+    Returns
+    -------
+    EvidenceResult
+        Evidence estimate with uncertainty
+    """
+    logger.info(f"Estimating evidence for {model.name} with {n_samples:,} samples")
+
+    # Ensure x_obs has batch dimension
+    if x_obs.dim() == 1:
+        x_obs = x_obs.unsqueeze(0)
+
+    flow.eval()
+    with torch.no_grad():
+        # Sample from flow posterior q(θ|x)
+        x_expanded = x_obs.expand(n_samples, -1)
+        theta_samples = flow.sample(n_samples, context=x_expanded)
+        if isinstance(theta_samples, tuple):
+            theta_samples = theta_samples[0]
+
+        # Compute log q(θ|x) - the flow's density
+        log_q = flow.log_prob(theta_samples, context=x_expanded)
+
+        # Compute log prior P(θ)
+        log_prior = model.log_prior(theta_samples)
+
+        # Compute log likelihood P(x|θ)
+        if compute_likelihood_fn is not None:
+            log_likelihood = compute_likelihood_fn(theta_samples, x_obs)
+        else:
+            # Default: assume flow was trained well, use simple estimate
+            # This is approximate but avoids recomputing the forward model
+            log_likelihood = log_q - log_prior + _estimate_log_normalizer(flow, model)
+
+        # Importance weights: w_i = P(x|θ_i) P(θ_i) / q(θ_i|x)
+        log_weights = log_likelihood + log_prior - log_q
+
+        # Handle numerical issues
+        log_weights = torch.nan_to_num(log_weights, nan=-np.inf, posinf=-np.inf, neginf=-np.inf)
+
+        # Log-sum-exp for numerical stability
+        max_log_w = log_weights.max()
+        log_evidence = max_log_w + torch.log(torch.exp(log_weights - max_log_w).mean())
+
+        # Estimate uncertainty via effective sample size
+        weights = torch.exp(log_weights - log_weights.max())
+        weights = weights / weights.sum()
+        ess = 1.0 / (weights ** 2).sum()
+
+        # Bootstrap uncertainty estimate
+        log_evidence_std = _bootstrap_evidence_std(log_weights, n_bootstrap=100)
+
+    result = EvidenceResult(
+        log_evidence=log_evidence.item(),
+        log_evidence_std=log_evidence_std,
+        effective_sample_size=ess.item(),
+        n_samples=n_samples,
+        method="importance_sampling"
+    )
+
+    logger.info(f"  {result}")
+    return result
+
+
+def _estimate_log_normalizer(flow, model: CosmologicalModel) -> float:
+    """
+    Estimate the log normalizing constant of the flow.
+
+    This is needed when we don't have an explicit likelihood.
+    We use the fact that ∫ q(θ|x) dθ = 1.
+    """
+    # For a well-trained flow, this should be approximately 0
+    # (flow is normalized). Return 0 as approximation.
+    return 0.0
+
+
+def _bootstrap_evidence_std(log_weights: torch.Tensor, n_bootstrap: int = 100) -> float:
+    """Estimate standard error of log evidence via bootstrap."""
+    n = len(log_weights)
+    estimates = []
+
+    for _ in range(n_bootstrap):
+        idx = torch.randint(0, n, (n,), device=log_weights.device)
+        lw_boot = log_weights[idx]
+        max_lw = lw_boot.max()
+        log_z = max_lw + torch.log(torch.exp(lw_boot - max_lw).mean())
+        estimates.append(log_z.item())
+
+    return np.std(estimates)
+
+
+def compute_evidence_ratio(
+    flow1,
+    flow2,
+    model1: CosmologicalModel,
+    model2: CosmologicalModel,
+    x_obs: torch.Tensor,
+    n_samples: int = 50000,
+) -> Dict:
+    """
+    Compute the Bayes factor (evidence ratio) between two models.
+
+    B₁₂ = P(x|M₁) / P(x|M₂)
+
+    Parameters
+    ----------
+    flow1, flow2 : Flow
+        Trained flows for each model
+    model1, model2 : CosmologicalModel
+        The two models to compare
+    x_obs : torch.Tensor
+        Observed data
+    n_samples : int
+        Samples for evidence estimation
+
+    Returns
+    -------
+    dict
+        Contains Bayes factor, log Bayes factor, interpretation, etc.
+    """
+    logger.info(f"Computing Bayes factor: {model1.short_name} vs {model2.short_name}")
+
+    # Estimate evidence for each model
+    ev1 = estimate_log_evidence(flow1, model1, x_obs, n_samples)
+    ev2 = estimate_log_evidence(flow2, model2, x_obs, n_samples)
+
+    log_bayes_factor = ev1.log_evidence - ev2.log_evidence
+    log_bf_std = np.sqrt(ev1.log_evidence_std**2 + ev2.log_evidence_std**2)
+
+    bayes_factor = np.exp(log_bayes_factor)
+
+    # Jeffreys' scale interpretation
+    if log_bayes_factor > 2.3:  # > 10
+        interpretation = f"Strong evidence for {model1.short_name}"
+    elif log_bayes_factor > 1.1:  # > 3
+        interpretation = f"Moderate evidence for {model1.short_name}"
+    elif log_bayes_factor > 0:
+        interpretation = f"Weak evidence for {model1.short_name}"
+    elif log_bayes_factor > -1.1:
+        interpretation = f"Weak evidence for {model2.short_name}"
+    elif log_bayes_factor > -2.3:
+        interpretation = f"Moderate evidence for {model2.short_name}"
+    else:
+        interpretation = f"Strong evidence for {model2.short_name}"
+
+    result = {
+        "bayes_factor": bayes_factor,
+        "log_bayes_factor": log_bayes_factor,
+        "log_bayes_factor_std": log_bf_std,
+        "model1": model1.short_name,
+        "model2": model2.short_name,
+        "evidence1": ev1,
+        "evidence2": ev2,
+        "interpretation": interpretation,
+    }
+
+    logger.info(f"  log(B₁₂) = {log_bayes_factor:.2f} ± {log_bf_std:.2f}")
+    logger.info(f"  B₁₂ = {bayes_factor:.3g}")
+    logger.info(f"  {interpretation}")
+
+    return result
+
+
+def harmonic_mean_evidence(
+    flow,
+    model: CosmologicalModel,
+    x_obs: torch.Tensor,
+    n_samples: int = 50000,
+    compute_likelihood_fn=None,
+) -> EvidenceResult:
+    """
+    Estimate evidence using harmonic mean estimator.
+
+    WARNING: The harmonic mean estimator has infinite variance in theory.
+    Use importance sampling (estimate_log_evidence) instead.
+    This is provided for comparison/validation only.
+
+    P(x)⁻¹ = E_posterior[P(x|θ)⁻¹]
+    """
+    logger.warning("Harmonic mean estimator has infinite variance. Use with caution.")
+
+    if x_obs.dim() == 1:
+        x_obs = x_obs.unsqueeze(0)
+
+    flow.eval()
+    with torch.no_grad():
+        x_expanded = x_obs.expand(n_samples, -1)
+        theta_samples = flow.sample(n_samples, context=x_expanded)
+        if isinstance(theta_samples, tuple):
+            theta_samples = theta_samples[0]
+
+        if compute_likelihood_fn is not None:
+            log_likelihood = compute_likelihood_fn(theta_samples, x_obs)
+        else:
+            log_q = flow.log_prob(theta_samples, context=x_expanded)
+            log_prior = model.log_prior(theta_samples)
+            log_likelihood = log_q - log_prior
+
+        # Harmonic mean: 1/Z ≈ mean(1/L)
+        neg_log_likelihood = -log_likelihood
+        max_nll = neg_log_likelihood.max()
+        log_inv_evidence = max_nll + torch.log(torch.exp(neg_log_likelihood - max_nll).mean())
+        log_evidence = -log_inv_evidence
+
+    return EvidenceResult(
+        log_evidence=log_evidence.item(),
+        log_evidence_std=np.nan,  # Unreliable
+        effective_sample_size=np.nan,
+        n_samples=n_samples,
+        method="harmonic_mean"
+    )

--- a/inference/tension.py
+++ b/inference/tension.py
@@ -1,0 +1,323 @@
+"""
+inference/tension.py
+--------------------
+Hubble tension quantification.
+
+This module provides multiple ways to quantify the Hubble tension:
+
+1. Probability of resolution: P(|ΔH₀| < ε)
+2. Posterior odds: P(concordance|data) / P(discordance|data)
+3. Tension significance in sigma
+4. Information-theoretic measures (KL divergence between subsets)
+
+The key insight: frequentist "n-sigma" tells you measurements disagree
+assuming they measure the same thing. Bayesian analysis tells you the
+probability they actually do measure the same thing.
+"""
+
+import torch
+import numpy as np
+from typing import Dict, Optional, Tuple, List
+from dataclasses import dataclass
+
+from config import DEVICE, logger
+from cosmology.base import CosmologicalModel
+
+
+@dataclass
+class TensionResult:
+    """Results from tension analysis."""
+    # Core metrics
+    prob_resolution: float
+    prob_resolution_std: float
+    epsilon: float  # tolerance used
+
+    # Distribution statistics
+    delta_H0_mean: float
+    delta_H0_std: float
+    delta_H0_median: float
+
+    # Credible intervals for ΔH₀
+    delta_H0_ci68: Tuple[float, float]
+    delta_H0_ci95: Tuple[float, float]
+
+    # Derived
+    sigma_tension: float  # Effective tension in sigma
+
+    def __repr__(self) -> str:
+        return (
+            f"TensionResult(\n"
+            f"  P(|ΔH₀|<{self.epsilon}) = {self.prob_resolution:.3f} ± {self.prob_resolution_std:.3f}\n"
+            f"  ΔH₀ = {self.delta_H0_mean:.2f} ± {self.delta_H0_std:.2f} km/s/Mpc\n"
+            f"  68% CI: [{self.delta_H0_ci68[0]:.2f}, {self.delta_H0_ci68[1]:.2f}]\n"
+            f"  95% CI: [{self.delta_H0_ci95[0]:.2f}, {self.delta_H0_ci95[1]:.2f}]\n"
+            f"  Effective tension: {self.sigma_tension:.1f}σ\n"
+            f")"
+        )
+
+
+class TensionAnalyzer:
+    """
+    Analyzer for Hubble tension quantification.
+
+    Provides Bayesian answers to questions like:
+    - What is P(the tension is resolvable)?
+    - How different are early vs late H₀?
+    - What epsilon would give 50% resolution probability?
+    """
+
+    def __init__(self, model: CosmologicalModel):
+        """
+        Initialize analyzer for a specific model.
+
+        Parameters
+        ----------
+        model : CosmologicalModel
+            Must have separate get_H0_early and get_H0_late methods
+        """
+        self.model = model
+
+    def analyze(
+        self,
+        theta_samples: torch.Tensor,
+        epsilon: float = 1.0
+    ) -> TensionResult:
+        """
+        Full tension analysis on posterior samples.
+
+        Parameters
+        ----------
+        theta_samples : torch.Tensor
+            Posterior samples, shape (n_samples, n_params)
+        epsilon : float
+            Tolerance for "resolution" in km/s/Mpc
+
+        Returns
+        -------
+        TensionResult
+            Comprehensive tension analysis results
+        """
+        logger.info(f"Analyzing Hubble tension for {self.model.name}")
+
+        # Extract H₀ values
+        H0_early = self.model.get_H0_early(theta_samples)
+        H0_late = self.model.get_H0_late(theta_samples)
+        delta_H0 = H0_late - H0_early  # Signed difference
+        abs_delta = torch.abs(delta_H0)
+
+        # Probability of resolution
+        resolved = (abs_delta < epsilon).float()
+        prob_res = resolved.mean().item()
+        prob_std = np.sqrt(prob_res * (1 - prob_res) / len(resolved))
+
+        # Distribution statistics
+        delta_mean = delta_H0.mean().item()
+        delta_std = delta_H0.std().item()
+        delta_median = delta_H0.median().item()
+
+        # Credible intervals
+        q16, q84 = delta_H0.quantile(torch.tensor([0.16, 0.84])).tolist()
+        q025, q975 = delta_H0.quantile(torch.tensor([0.025, 0.975])).tolist()
+
+        # Effective sigma (assuming Gaussian)
+        # "How many sigma from zero?"
+        sigma_tension = abs(delta_mean) / delta_std if delta_std > 0 else 0
+
+        result = TensionResult(
+            prob_resolution=prob_res,
+            prob_resolution_std=prob_std,
+            epsilon=epsilon,
+            delta_H0_mean=delta_mean,
+            delta_H0_std=delta_std,
+            delta_H0_median=delta_median,
+            delta_H0_ci68=(q16, q84),
+            delta_H0_ci95=(q025, q975),
+            sigma_tension=sigma_tension,
+        )
+
+        logger.info(f"\n{result}")
+        return result
+
+    def probability_curve(
+        self,
+        theta_samples: torch.Tensor,
+        epsilon_range: Optional[List[float]] = None
+    ) -> Dict[str, np.ndarray]:
+        """
+        Compute P(|ΔH₀| < ε) for a range of ε values.
+
+        This shows how the resolution probability varies with tolerance.
+
+        Parameters
+        ----------
+        theta_samples : torch.Tensor
+            Posterior samples
+        epsilon_range : list, optional
+            Tolerance values to evaluate. Default: [0.1, 0.5, 1, 2, 3, 4, 5]
+
+        Returns
+        -------
+        dict
+            {"epsilon": [...], "probability": [...], "std_error": [...]}
+        """
+        if epsilon_range is None:
+            epsilon_range = [0.1, 0.5, 1.0, 2.0, 3.0, 4.0, 5.0]
+
+        abs_delta = torch.abs(
+            self.model.get_H0_late(theta_samples) -
+            self.model.get_H0_early(theta_samples)
+        )
+
+        probabilities = []
+        std_errors = []
+
+        for eps in epsilon_range:
+            resolved = (abs_delta < eps).float()
+            p = resolved.mean().item()
+            se = np.sqrt(p * (1 - p) / len(resolved))
+            probabilities.append(p)
+            std_errors.append(se)
+
+        return {
+            "epsilon": np.array(epsilon_range),
+            "probability": np.array(probabilities),
+            "std_error": np.array(std_errors),
+        }
+
+    def find_critical_epsilon(
+        self,
+        theta_samples: torch.Tensor,
+        target_probability: float = 0.5
+    ) -> float:
+        """
+        Find the ε where P(|ΔH₀| < ε) = target_probability.
+
+        This is the "half-width" of the tension: the tolerance needed
+        for a 50% chance of agreement.
+
+        Parameters
+        ----------
+        theta_samples : torch.Tensor
+            Posterior samples
+        target_probability : float
+            Target probability (default 0.5 for median)
+
+        Returns
+        -------
+        float
+            Critical epsilon value
+        """
+        abs_delta = torch.abs(
+            self.model.get_H0_late(theta_samples) -
+            self.model.get_H0_early(theta_samples)
+        )
+
+        # Critical epsilon is the quantile of |ΔH₀|
+        critical_eps = abs_delta.quantile(target_probability).item()
+
+        logger.info(f"ε for P={target_probability:.0%}: {critical_eps:.2f} km/s/Mpc")
+        return critical_eps
+
+    def compare_subsets(
+        self,
+        theta_samples: torch.Tensor,
+        early_only_samples: torch.Tensor,
+        late_only_samples: torch.Tensor,
+    ) -> Dict:
+        """
+        Compare posterior constraints from different data subsets.
+
+        This is useful for diagnosing which data are in tension.
+
+        Parameters
+        ----------
+        theta_samples : torch.Tensor
+            Full dataset posterior
+        early_only_samples : torch.Tensor
+            Posterior using only early-universe data (CMB/BAO)
+        late_only_samples : torch.Tensor
+            Posterior using only late-universe data (SNe/Cepheids)
+
+        Returns
+        -------
+        dict
+            Comparison statistics
+        """
+        # Get H0 from each
+        H0_full = self.model.get_H0_late(theta_samples)  # or early, same in concordance
+        H0_early = self.model.get_H0_late(early_only_samples)
+        H0_late = self.model.get_H0_late(late_only_samples)
+
+        return {
+            "H0_full": {
+                "mean": H0_full.mean().item(),
+                "std": H0_full.std().item(),
+            },
+            "H0_early_only": {
+                "mean": H0_early.mean().item(),
+                "std": H0_early.std().item(),
+            },
+            "H0_late_only": {
+                "mean": H0_late.mean().item(),
+                "std": H0_late.std().item(),
+            },
+            "tension_sigma": abs(H0_early.mean() - H0_late.mean()).item() / \
+                            np.sqrt(H0_early.std()**2 + H0_late.std()**2).item(),
+        }
+
+
+def compute_suspiciousness(
+    theta_samples_1: torch.Tensor,
+    theta_samples_2: torch.Tensor,
+    model: CosmologicalModel,
+) -> Dict:
+    """
+    Compute the "suspiciousness" statistic for dataset tension.
+
+    This is based on Handley & Lemos (2019):
+    S = D_KL(P₁ || P) + D_KL(P₂ || P) - D_KL(P₁₂ || P)
+
+    where P is the prior, P₁, P₂ are single-dataset posteriors,
+    and P₁₂ is the combined posterior.
+
+    High S indicates datasets are in tension.
+
+    Parameters
+    ----------
+    theta_samples_1 : torch.Tensor
+        Posterior from dataset 1 (e.g., early universe)
+    theta_samples_2 : torch.Tensor
+        Posterior from dataset 2 (e.g., late universe)
+    model : CosmologicalModel
+        The cosmological model
+
+    Returns
+    -------
+    dict
+        Suspiciousness statistic and interpretation
+    """
+    # Simplified: compare means
+    # Full implementation would compute KL divergences
+
+    mean_1 = theta_samples_1.mean(dim=0)
+    mean_2 = theta_samples_2.mean(dim=0)
+    std_1 = theta_samples_1.std(dim=0)
+    std_2 = theta_samples_2.std(dim=0)
+
+    # Approximate tension as Mahalanobis distance
+    diff = mean_1 - mean_2
+    combined_var = std_1**2 + std_2**2
+    chi2 = (diff**2 / combined_var).sum().item()
+    n_params = len(mean_1)
+
+    # p-value from chi-squared distribution
+    from scipy.stats import chi2 as chi2_dist
+    p_value = 1 - chi2_dist.cdf(chi2, df=n_params)
+
+    return {
+        "chi2": chi2,
+        "n_params": n_params,
+        "p_value": p_value,
+        "sigma": np.sqrt(chi2),  # Approximate sigma equivalent
+        "interpretation": "suspicious" if p_value < 0.01 else "consistent",
+    }

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ main.py
 -------
 Command-line interface for the Hubble cosmological inference pipeline.
 
-Usage:
+Basic Usage:
     hubble prep        # Prepare observational data
     hubble simulate    # Generate training data
     hubble train       # Train the normalizing flow
@@ -11,11 +11,22 @@ Usage:
     hubble sample      # Draw posterior samples
     hubble analyze     # Analyze posterior samples
     hubble run         # Run the full pipeline
+
+Model Comparison:
+    hubble models              # List available cosmological models
+    hubble train-model         # Train flow for a specific model
+    hubble compare             # Compare models via Bayes factors
+    hubble tension             # Quantify Hubble tension
+
+Visualization:
+    hubble plot-corner         # Generate corner plot
+    hubble plot-tension        # Plot tension probability curve
 """
 
 import click
+from pathlib import Path
 
-from config import logger, set_seed
+from config import logger, set_seed, RESULTS
 
 
 @click.group()
@@ -29,6 +40,10 @@ def cli(seed: int, verbose: bool):
         logger.setLevel(logging.DEBUG)
 
 
+# ===========================================================================
+# Basic Pipeline Commands
+# ===========================================================================
+
 @cli.command()
 def prep():
     """Prepare observational data (Pantheon+, BAO)."""
@@ -39,9 +54,12 @@ def prep():
 @cli.command()
 @click.option("--n-samples", "-n", default=None, type=int,
               help="Number of training samples (default: 300,000)")
-def simulate(n_samples: int):
+@click.option("--model", "-m", default="concordance",
+              help="Cosmological model to simulate (default: concordance)")
+def simulate(n_samples: int, model: str):
     """Generate training data using Sobol sampling."""
     import sim
+    # For now, use default simulation (model-specific simulation TBD)
     sim.run(n_samples=n_samples)
 
 
@@ -57,7 +75,6 @@ def train(epochs: int, batch_size: int, lr: float):
     import flow_train
     from config import config
 
-    # Override config if options provided
     if epochs:
         config.training.n_epochs = epochs
     if batch_size:
@@ -107,28 +124,11 @@ def run(ctx, n_train: int, epochs: int, n_posterior: int):
     logger.info("Running full Hubble pipeline")
     logger.info("=" * 60)
 
-    # Step 1: Prep
-    logger.info("\n[1/6] Preparing data...")
     ctx.invoke(prep)
-
-    # Step 2: Simulate
-    logger.info("\n[2/6] Generating training data...")
     ctx.invoke(simulate, n_samples=n_train)
-
-    # Step 3: Train
-    logger.info("\n[3/6] Training flow model...")
     ctx.invoke(train, epochs=epochs)
-
-    # Step 4: Observe
-    logger.info("\n[4/6] Computing observed summary...")
     ctx.invoke(observe)
-
-    # Step 5: Sample
-    logger.info("\n[5/6] Drawing posterior samples...")
     ctx.invoke(sample, n_samples=n_posterior)
-
-    # Step 6: Analyze
-    logger.info("\n[6/6] Analyzing results...")
     ctx.invoke(analyze)
 
     logger.info("\n" + "=" * 60)
@@ -136,14 +136,362 @@ def run(ctx, n_train: int, epochs: int, n_posterior: int):
     logger.info("=" * 60)
 
 
+# ===========================================================================
+# Model Comparison Commands
+# ===========================================================================
+
+@cli.command("models")
+def list_models():
+    """List available cosmological models."""
+    from cosmology import MODELS
+
+    click.echo("\nAvailable Cosmological Models")
+    click.echo("=" * 50)
+
+    for name, model_cls in MODELS.items():
+        model = model_cls()
+        click.echo(f"\n{name}:")
+        click.echo(f"  Name: {model.name}")
+        click.echo(f"  Parameters: {model.n_params}")
+        click.echo(f"  Symbols: {', '.join(model.param_symbols)}")
+        if model.description:
+            # Wrap description
+            desc = model.description
+            if len(desc) > 60:
+                desc = desc[:57] + "..."
+            click.echo(f"  Description: {desc}")
+
+    # Check for trained flows
+    from models import list_available_flows
+    available = list_available_flows()
+    if available:
+        click.echo(f"\nTrained flows available: {', '.join(available)}")
+    else:
+        click.echo("\nNo trained flows found. Run 'hubble train-model' first.")
+
+
+@cli.command("train-model")
+@click.argument("model_name")
+@click.option("--n-samples", "-n", default=100000, type=int,
+              help="Number of training samples (default: 100,000)")
+@click.option("--epochs", "-e", default=10, type=int,
+              help="Number of training epochs (default: 10)")
+@click.option("--batch-size", "-b", default=1024, type=int,
+              help="Batch size (default: 1024)")
+@click.option("--lr", default=1e-3, type=float,
+              help="Learning rate (default: 1e-3)")
+def train_model(model_name: str, n_samples: int, epochs: int, batch_size: int, lr: float):
+    """
+    Train a flow for a specific cosmological model.
+
+    MODEL_NAME: One of 'concordance', 'discordance', 'wcdm', 'early_de'
+    """
+    import torch
+    from torch.utils.data import DataLoader, TensorDataset
+    import h5py
+
+    from cosmology import get_model
+    from models import build_flow_for_model, save_flow
+    from config import config, paths, DEVICE
+    import forward
+
+    logger.info("=" * 60)
+    logger.info(f"Training flow for model: {model_name}")
+    logger.info("=" * 60)
+
+    # Get model
+    model = get_model(model_name)
+    logger.info(f"Model: {model.name} ({model.n_params} parameters)")
+
+    # Load observations
+    logger.info("Loading observations...")
+    with h5py.File(paths.obs_h5, "r") as f:
+        obs_arrays = {k: torch.tensor(f[k][...], device=DEVICE) for k in f}
+    callbacks = torch.load(paths.residual_fns)
+    obs = {**obs_arrays, **callbacks}
+
+    # Generate training data for this model
+    logger.info(f"Generating {n_samples:,} training samples...")
+    theta_all = model.sample_prior(n_samples)
+
+    x_list = []
+    for i, theta in enumerate(theta_all):
+        if i % 5000 == 0:
+            logger.info(f"  Progress: {i:,}/{n_samples:,}")
+        x_list.append(model.summary_vector(theta, obs))
+    x_all = torch.stack(x_list)
+
+    logger.info(f"  theta shape: {theta_all.shape}, x shape: {x_all.shape}")
+
+    # Build and train flow
+    flow = build_flow_for_model(model_name)
+    n_params = sum(p.numel() for p in flow.parameters())
+    logger.info(f"Flow has {n_params:,} parameters")
+
+    loader = DataLoader(TensorDataset(x_all, theta_all), batch_size=batch_size, shuffle=True)
+    optimizer = torch.optim.Adam(flow.parameters(), lr=lr)
+
+    logger.info(f"Training for {epochs} epochs...")
+    best_loss = float("inf")
+
+    for epoch in range(epochs):
+        epoch_loss = 0.0
+        n_batches = 0
+
+        for xb, tb in loader:
+            loss = -flow.log_prob(inputs=tb, context=xb).mean()
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+            epoch_loss += loss.item()
+            n_batches += 1
+
+        avg_loss = epoch_loss / n_batches
+        marker = " *" if avg_loss < best_loss else ""
+        if avg_loss < best_loss:
+            best_loss = avg_loss
+        logger.info(f"  Epoch {epoch+1:2d}/{epochs}  loss: {avg_loss:.4f}{marker}")
+
+    # Save
+    metadata = {
+        "n_samples": n_samples,
+        "epochs": epochs,
+        "batch_size": batch_size,
+        "lr": lr,
+        "final_loss": avg_loss,
+    }
+    save_flow(flow, model_name=model_name, metadata=metadata)
+    logger.info(f"Training complete for {model_name}!")
+
+
+@cli.command("compare")
+@click.option("--models", "-m", multiple=True, default=["concordance", "discordance"],
+              help="Models to compare (can specify multiple)")
+@click.option("--n-samples", "-n", default=50000, type=int,
+              help="Samples for evidence estimation (default: 50,000)")
+@click.option("--epsilon", "-e", default=1.0, type=float,
+              help="H0 tolerance for tension analysis (default: 1.0)")
+@click.option("--output", "-o", default=None, type=str,
+              help="Output file for results (JSON)")
+def compare_models(models: tuple, n_samples: int, epsilon: float, output: str):
+    """
+    Compare cosmological models using Bayes factors.
+
+    Computes evidence for each model and reports:
+    - Bayes factors between model pairs
+    - Posterior model probabilities
+    - Tension resolution probability under each model
+    """
+    import torch
+    from cosmology import get_model
+    from models import load_flow, check_flow_exists
+    from config import paths, DEVICE
+    from inference.comparison import ModelComparison
+
+    logger.info("=" * 60)
+    logger.info("Bayesian Model Comparison")
+    logger.info("=" * 60)
+
+    # Check all flows exist
+    for model_name in models:
+        if not check_flow_exists(model_name):
+            raise click.ClickException(
+                f"No trained flow for '{model_name}'. "
+                f"Run 'hubble train-model {model_name}' first."
+            )
+
+    # Load observed summary
+    if not paths.x_obs.exists():
+        raise click.ClickException(
+            "Observed summary not found. Run 'hubble observe' first."
+        )
+    x_obs = torch.load(paths.x_obs, map_location=DEVICE)
+
+    # Set up comparison
+    comparison = ModelComparison()
+    for model_name in models:
+        model = get_model(model_name)
+        flow = load_flow(model_name)
+        comparison.add_model(model_name, flow, model)
+
+    # Run comparison
+    results = comparison.compare(x_obs, n_samples=n_samples, epsilon=epsilon)
+
+    # Print summary
+    click.echo("\n" + str(results))
+    click.echo("\n" + comparison.get_tension_summary())
+
+    # Save if requested
+    if output:
+        output_path = Path(output)
+        results.save(output_path)
+
+
+@cli.command("tension")
+@click.option("--model", "-m", default="discordance",
+              help="Model to use for tension analysis (default: discordance)")
+@click.option("--n-samples", "-n", default=100000, type=int,
+              help="Number of posterior samples (default: 100,000)")
+@click.option("--epsilon", "-e", default=1.0, type=float,
+              help="H0 tolerance in km/s/Mpc (default: 1.0)")
+def tension_analysis(model: str, n_samples: int, epsilon: float):
+    """
+    Quantify the Hubble tension under a specific model.
+
+    Reports:
+    - P(|ΔH₀| < ε): probability tension is resolvable
+    - ΔH₀ distribution statistics
+    - Resolution probability curve
+    """
+    import torch
+    from cosmology import get_model
+    from models import load_flow, check_flow_exists
+    from config import paths, DEVICE
+    from inference.tension import TensionAnalyzer
+
+    logger.info("=" * 60)
+    logger.info(f"Hubble Tension Analysis ({model})")
+    logger.info("=" * 60)
+
+    if not check_flow_exists(model):
+        raise click.ClickException(
+            f"No trained flow for '{model}'. "
+            f"Run 'hubble train-model {model}' first."
+        )
+
+    # Load
+    cosmo_model = get_model(model)
+    flow = load_flow(model)
+    x_obs = torch.load(paths.x_obs, map_location=DEVICE)
+
+    # Sample posterior
+    logger.info(f"Drawing {n_samples:,} posterior samples...")
+    flow.eval()
+    with torch.no_grad():
+        x_exp = x_obs.unsqueeze(0).expand(n_samples, -1) if x_obs.dim() == 1 else x_obs.expand(n_samples, -1)
+        theta_samples = flow.sample(n_samples, context=x_exp)
+        if isinstance(theta_samples, tuple):
+            theta_samples = theta_samples[0]
+
+    # Analyze
+    analyzer = TensionAnalyzer(cosmo_model)
+    result = analyzer.analyze(theta_samples, epsilon=epsilon)
+
+    # Probability curve
+    curve = analyzer.probability_curve(theta_samples)
+    click.echo("\nResolution Probability Curve:")
+    click.echo("-" * 40)
+    for eps, prob, err in zip(curve["epsilon"], curve["probability"], curve["std_error"]):
+        bar = "█" * int(prob * 30)
+        click.echo(f"  ε={eps:4.1f}: {prob:5.1%} ± {err:4.1%} {bar}")
+
+    # Critical epsilon
+    eps_50 = analyzer.find_critical_epsilon(theta_samples, 0.5)
+    click.echo(f"\nCritical ε (50% resolution): {eps_50:.2f} km/s/Mpc")
+
+    # Interpretation
+    click.echo("\n" + "=" * 40)
+    if result.prob_resolution < 0.05:
+        click.echo("CONCLUSION: Strong evidence that Hubble tension is REAL")
+        click.echo(f"  Only {result.prob_resolution:.1%} chance of resolution within {epsilon} km/s/Mpc")
+    elif result.prob_resolution < 0.32:
+        click.echo("CONCLUSION: Moderate evidence for Hubble tension")
+    else:
+        click.echo("CONCLUSION: Tension may be resolvable")
+
+
+# ===========================================================================
+# Visualization Commands
+# ===========================================================================
+
+@cli.command("plot-corner")
+@click.option("--model", "-m", default="concordance",
+              help="Model to plot (default: concordance)")
+@click.option("--output", "-o", default=None, type=str,
+              help="Output file path (default: results/corner_{model}.png)")
+def plot_corner_cmd(model: str, output: str):
+    """Generate a corner plot of posterior samples."""
+    import torch
+    from cosmology import get_model
+    from models import load_flow, check_flow_exists
+    from config import paths, DEVICE, RESULTS
+    from analysis.visualize import plot_corner
+
+    if not check_flow_exists(model):
+        raise click.ClickException(f"No trained flow for '{model}'.")
+
+    cosmo_model = get_model(model)
+    flow = load_flow(model)
+    x_obs = torch.load(paths.x_obs, map_location=DEVICE)
+
+    logger.info(f"Generating corner plot for {model}...")
+
+    flow.eval()
+    with torch.no_grad():
+        x_exp = x_obs.unsqueeze(0).expand(50000, -1) if x_obs.dim() == 1 else x_obs.expand(50000, -1)
+        theta_samples = flow.sample(50000, context=x_exp)
+        if isinstance(theta_samples, tuple):
+            theta_samples = theta_samples[0]
+
+    output_path = Path(output) if output else RESULTS / f"corner_{model}.png"
+    plot_corner(theta_samples, cosmo_model, output_path=output_path,
+                title=f"Posterior: {cosmo_model.name}")
+
+    click.echo(f"Saved corner plot to {output_path}")
+
+
+@cli.command("plot-tension")
+@click.option("--model", "-m", default="discordance",
+              help="Model to use (default: discordance)")
+@click.option("--output", "-o", default=None, type=str,
+              help="Output file path")
+def plot_tension_cmd(model: str, output: str):
+    """Plot the tension resolution probability curve."""
+    import torch
+    from cosmology import get_model
+    from models import load_flow, check_flow_exists
+    from config import paths, DEVICE, RESULTS
+    from inference.tension import TensionAnalyzer
+    from analysis.visualize import plot_tension_curve
+
+    if not check_flow_exists(model):
+        raise click.ClickException(f"No trained flow for '{model}'.")
+
+    cosmo_model = get_model(model)
+    flow = load_flow(model)
+    x_obs = torch.load(paths.x_obs, map_location=DEVICE)
+
+    logger.info(f"Generating tension curve for {model}...")
+
+    flow.eval()
+    with torch.no_grad():
+        x_exp = x_obs.unsqueeze(0).expand(100000, -1) if x_obs.dim() == 1 else x_obs.expand(100000, -1)
+        theta_samples = flow.sample(100000, context=x_exp)
+        if isinstance(theta_samples, tuple):
+            theta_samples = theta_samples[0]
+
+    analyzer = TensionAnalyzer(cosmo_model)
+    curve = analyzer.probability_curve(theta_samples,
+                                       epsilon_range=[0.1, 0.25, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 5.0])
+
+    output_path = Path(output) if output else RESULTS / f"tension_curve_{model}.png"
+    plot_tension_curve(curve, output_path=output_path)
+
+    click.echo(f"Saved tension curve to {output_path}")
+
+
+# ===========================================================================
+# Info Command
+# ===========================================================================
+
 @cli.command()
 def info():
     """Display configuration and system information."""
     import torch
     from config import config, DEVICE, paths, ROOT
 
-    click.echo("Hubble Configuration")
-    click.echo("=" * 40)
+    click.echo("\nHubble Configuration")
+    click.echo("=" * 50)
 
     click.echo(f"\nProject root: {ROOT}")
     click.echo(f"Device: {DEVICE}")
@@ -152,12 +500,11 @@ def info():
         click.echo(f"CUDA device: {torch.cuda.get_device_name(0)}")
 
     click.echo(f"\nFlow architecture:")
-    click.echo(f"  Dimensions: {config.flow.dim}")
     click.echo(f"  Hidden dim: {config.flow.hidden_dim}")
     click.echo(f"  Layers: {config.flow.n_layers}")
 
     click.echo(f"\nTraining config:")
-    click.echo(f"  Train samples: {config.training.n_train_samples:,}")
+    click.echo(f"  Default samples: {config.training.n_train_samples:,}")
     click.echo(f"  Batch size: {config.training.batch_size}")
     click.echo(f"  Learning rate: {config.training.learning_rate}")
     click.echo(f"  Epochs: {config.training.n_epochs}")
@@ -165,14 +512,17 @@ def info():
     click.echo(f"\nInference config:")
     click.echo(f"  Posterior samples: {config.inference.n_posterior_samples:,}")
 
-    click.echo(f"\nParameter bounds:")
-    for i, name in enumerate(config.physics.param_names):
-        lo = config.physics.theta_min[i]
-        hi = config.physics.theta_max[i]
-        click.echo(f"  {name}: [{lo}, {hi}]")
+    # Available models
+    from cosmology import MODELS as COSMO_MODELS
+    click.echo(f"\nCosmological models: {', '.join(COSMO_MODELS.keys())}")
+
+    # Trained flows
+    from models import list_available_flows
+    available = list_available_flows()
+    click.echo(f"Trained flows: {', '.join(available) if available else 'None'}")
 
     click.echo(f"\nData paths:")
-    click.echo(f"  Raw data: {paths.pantheon_data.parent}")
+    click.echo(f"  Raw: {paths.pantheon_data.parent}")
     click.echo(f"  Processed: {paths.obs_h5.parent}")
     click.echo(f"  Models: {paths.flow_weights.parent}")
     click.echo(f"  Results: {paths.posterior.parent}")

--- a/models.py
+++ b/models.py
@@ -3,6 +3,8 @@ models.py
 ---------
 Shared neural network model definitions.
 This ensures flow architecture is defined in ONE place only.
+
+Supports multiple cosmological models with different parameter dimensions.
 """
 
 import torch
@@ -10,8 +12,10 @@ import nflows
 from nflows.transforms import MaskedAffineAutoregressiveTransform, CompositeTransform
 from nflows.distributions import StandardNormal
 from nflows.flows import Flow
+from pathlib import Path
+from typing import Optional, Union
 
-from config import config, paths, DEVICE, logger
+from config import config, paths, DEVICE, MODELS, logger
 
 
 def build_flow(
@@ -58,7 +62,44 @@ def build_flow(
     return flow
 
 
-def save_flow(flow: Flow, metadata: dict = None) -> None:
+def build_flow_for_model(model_name: str, hidden_dim: int = None, n_layers: int = None) -> Flow:
+    """
+    Build a flow for a specific cosmological model.
+
+    Parameters
+    ----------
+    model_name : str
+        Name of the cosmological model (e.g., "concordance", "discordance")
+    hidden_dim : int, optional
+        Hidden layer dimension. Default from config.
+    n_layers : int, optional
+        Number of MAF layers. Default from config.
+
+    Returns
+    -------
+    Flow
+        Flow with correct dimensionality for the model
+    """
+    from cosmology import get_model
+
+    model = get_model(model_name)
+    dim = model.n_params
+
+    logger.info(f"Building flow for {model.name} (dim={dim})")
+    return build_flow(dim=dim, hidden_dim=hidden_dim, n_layers=n_layers)
+
+
+def get_flow_path(model_name: str) -> Path:
+    """Get the path for a model's flow weights."""
+    return MODELS / f"flow_{model_name}.pt"
+
+
+def save_flow(
+    flow: Flow,
+    model_name: str = None,
+    path: Path = None,
+    metadata: dict = None
+) -> None:
     """
     Save flow model with optional metadata for reproducibility.
 
@@ -66,30 +107,50 @@ def save_flow(flow: Flow, metadata: dict = None) -> None:
     ----------
     flow : Flow
         The trained flow model.
+    model_name : str, optional
+        Name of the cosmological model. Used to determine save path.
+    path : Path, optional
+        Explicit path to save to. Overrides model_name-based path.
     metadata : dict, optional
         Additional metadata (hyperparameters, training info, etc.)
     """
+    if path is None:
+        if model_name:
+            path = get_flow_path(model_name)
+        else:
+            path = paths.flow_weights
+
+    # Infer dimension from flow
+    dim = flow._distribution._shape[0]
+
     save_dict = {
         "state_dict": flow.state_dict(),
         "config": {
-            "dim": config.flow.dim,
+            "dim": dim,
             "hidden_dim": config.flow.hidden_dim,
             "n_layers": config.flow.n_layers,
-        }
+        },
+        "model_name": model_name,
     }
     if metadata:
         save_dict["metadata"] = metadata
 
-    torch.save(save_dict, paths.flow_weights)
-    logger.info(f"Saved flow model to {paths.flow_weights}")
+    torch.save(save_dict, path)
+    logger.info(f"Saved flow model to {path}")
 
 
-def load_flow(device: torch.device = None) -> Flow:
+def load_flow(
+    path_or_model: Union[Path, str] = None,
+    device: torch.device = None
+) -> Flow:
     """
     Load a trained flow model from disk.
 
     Parameters
     ----------
+    path_or_model : Path or str, optional
+        Either a path to the weights file, or a model name (e.g., "concordance").
+        If None, loads the default flow.
     device : torch.device, optional
         Device to load the model onto.
 
@@ -100,10 +161,19 @@ def load_flow(device: torch.device = None) -> Flow:
     """
     device = device or DEVICE
 
-    if not paths.flow_weights.exists():
-        raise FileNotFoundError(f"Flow weights not found at {paths.flow_weights}")
+    # Determine path
+    if path_or_model is None:
+        path = paths.flow_weights
+    elif isinstance(path_or_model, str) and not Path(path_or_model).exists():
+        # Assume it's a model name
+        path = get_flow_path(path_or_model)
+    else:
+        path = Path(path_or_model)
 
-    checkpoint = torch.load(paths.flow_weights, map_location=device)
+    if not path.exists():
+        raise FileNotFoundError(f"Flow weights not found at {path}")
+
+    checkpoint = torch.load(path, map_location=device)
 
     # Handle both old format (just state_dict) and new format (dict with config)
     if isinstance(checkpoint, dict) and "state_dict" in checkpoint:
@@ -123,5 +193,19 @@ def load_flow(device: torch.device = None) -> Flow:
     flow.load_state_dict(state_dict)
     flow.eval()
 
-    logger.info(f"Loaded flow model from {paths.flow_weights}")
+    logger.info(f"Loaded flow model from {path}")
     return flow
+
+
+def check_flow_exists(model_name: str) -> bool:
+    """Check if a trained flow exists for a model."""
+    return get_flow_path(model_name).exists()
+
+
+def list_available_flows() -> list:
+    """List all available trained flows."""
+    available = []
+    for path in MODELS.glob("flow_*.pt"):
+        model_name = path.stem.replace("flow_", "")
+        available.append(model_name)
+    return available


### PR DESCRIPTION
Major new features:

Cosmological Models (cosmology/):
- base.py: Abstract base class with prior sampling, parameter handling
- concordance.py: Standard ΛCDM with single H₀ (5 params)
- discordance.py: Split H₀ for early/late universe (6 params)
- wcdm.py: Dynamic dark energy w₀-wa model (5 params)
- early_de.py: Early dark energy model (7 params)

Inference Framework (inference/):
- evidence.py: Bayesian evidence estimation via importance sampling
- tension.py: Hubble tension quantification with P(|ΔH₀|<ε)
- comparison.py: Full model comparison with Bayes factors

Visualization (analysis/):
- visualize.py: Corner plots, tension curves, H₀ posteriors

CLI Enhancements:
- hubble models: List available cosmological models
- hubble train-model MODEL: Train flow for specific model
- hubble compare: Compare models via Bayes factors
- hubble tension: Quantify Hubble tension probability
- hubble plot-corner/plot-tension: Visualization commands

Updated models.py:
- Support for multiple model flows
- Model-specific save/load paths
- Flow listing utilities

Key scientific capability:
- Direct answer to "What is P(Hubble tension is resolvable)?"
- Bayes factor comparison between concordance/discordance
- Not just n-sigma, but actual posterior probability