### PR TITLE
Fix linting issues and critical bug in save_flow call

### DIFF
--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -6,9 +6,9 @@ Analysis and visualization modules.
 
 from analysis.visualize import (
     plot_corner,
-    plot_tension_curve,
-    plot_model_comparison,
     plot_H0_posteriors,
+    plot_model_comparison,
+    plot_tension_curve,
 )
 
 __all__ = [

--- a/analysis/visualize.py
+++ b/analysis/visualize.py
@@ -10,12 +10,13 @@ Generates publication-quality plots:
 - Resolution probability curves
 """
 
-import numpy as np
-from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Any
 import warnings
+from pathlib import Path
+from typing import Any, Optional
 
-from config import paths, logger
+import numpy as np
+
+from config import logger
 from cosmology.base import CosmologicalModel
 
 # Lazy import matplotlib to avoid issues if not installed
@@ -30,8 +31,8 @@ def _get_plt():
             import matplotlib.pyplot as plt
             plt.style.use('seaborn-v0_8-whitegrid')
             _plt = plt
-        except ImportError:
-            raise ImportError("matplotlib required for plotting. Install with: pip install matplotlib")
+        except ImportError as e:
+            raise ImportError("matplotlib required for plotting. Install with: pip install matplotlib") from e
     return _plt
 
 
@@ -42,7 +43,7 @@ def _get_corner():
             import corner
             _corner = corner
         except ImportError:
-            warnings.warn("corner package not installed. Install with: pip install corner")
+            warnings.warn("corner package not installed. Install with: pip install corner", stacklevel=2)
             _corner = None
     return _corner
 
@@ -50,7 +51,7 @@ def _get_corner():
 def plot_corner(
     theta_samples,
     model: CosmologicalModel,
-    truths: Optional[List[float]] = None,
+    truths: Optional[list[float]] = None,
     output_path: Optional[Path] = None,
     title: Optional[str] = None,
     **kwargs
@@ -78,11 +79,11 @@ def plot_corner(
     matplotlib.figure.Figure
         The corner plot figure
     """
-    plt = _get_plt()
+    _get_plt()
     corner = _get_corner()
 
     if corner is None:
-        warnings.warn("corner package not available, skipping corner plot")
+        warnings.warn("corner package not available, skipping corner plot", stacklevel=2)
         return None
 
     # Convert to numpy
@@ -117,7 +118,7 @@ def plot_corner(
 
 
 def plot_tension_curve(
-    tension_curve: Dict[str, np.ndarray],
+    tension_curve: dict[str, np.ndarray],
     output_path: Optional[Path] = None,
     title: str = "Hubble Tension Resolution Probability",
 ) -> Any:
@@ -232,9 +233,9 @@ def plot_model_comparison(
 
 
 def plot_H0_posteriors(
-    posteriors: Dict[str, Tuple[np.ndarray, CosmologicalModel]],
+    posteriors: dict[str, tuple[np.ndarray, CosmologicalModel]],
     output_path: Optional[Path] = None,
-    reference_values: Optional[Dict[str, float]] = None,
+    reference_values: Optional[dict[str, float]] = None,
 ) -> Any:
     """
     Plot H₀ posterior distributions from multiple models.
@@ -355,7 +356,7 @@ def plot_delta_H0_distribution(
     ax.axvline(mean_delta, color='blue', linestyle='--', label=f'Mean: {mean_delta:.2f}')
 
     textstr = f'ΔH₀ = {mean_delta:.2f} ± {std_delta:.2f}\nP(resolution) = {prob_res:.1%}'
-    props = dict(boxstyle='round', facecolor='wheat', alpha=0.8)
+    props = {'boxstyle': 'round', 'facecolor': 'wheat', 'alpha': 0.8}
     ax.text(0.95, 0.95, textstr, transform=ax.transAxes, fontsize=12,
            verticalalignment='top', horizontalalignment='right', bbox=props)
 
@@ -379,7 +380,7 @@ def plot_delta_H0_distribution(
 # =============================================================================
 
 def export_posterior_table(
-    stats: Dict[str, Dict[str, float]],
+    stats: dict[str, dict[str, float]],
     model_name: str = "Model",
     output_path: Optional[Path] = None,
     caption: str = "Posterior parameter constraints",
@@ -505,7 +506,7 @@ def export_model_comparison_table(
 
 
 def export_tension_table(
-    tension_results: Dict[str, Any],
+    tension_results: dict[str, Any],
     output_path: Optional[Path] = None,
     caption: str = "Hubble tension analysis",
 ) -> str:

--- a/config.py
+++ b/config.py
@@ -5,11 +5,11 @@ Centralized configuration for paths, hyperparameters, and device settings.
 All other modules should import from here instead of hardcoding values.
 """
 
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List
+
 import torch
-import logging
 
 # ---------------------------------------------------------------------------
 # Path Configuration
@@ -79,10 +79,10 @@ class PhysicsConfig:
     """Physics model configuration."""
     integration_points: int = 128
     # Parameter bounds: θ = (H0, Ωm, Ωde, w0, wa)
-    theta_min: List[float] = field(default_factory=lambda: [50.0, 0.30, 0.60, -1.0, 0.0])
-    theta_max: List[float] = field(default_factory=lambda: [90.0, 0.40, 0.70, -0.5, 0.5])
+    theta_min: list[float] = field(default_factory=lambda: [50.0, 0.30, 0.60, -1.0, 0.0])
+    theta_max: list[float] = field(default_factory=lambda: [90.0, 0.40, 0.70, -0.5, 0.5])
     # Parameter names for reference
-    param_names: List[str] = field(default_factory=lambda: ["H0", "Ωm", "Ωde", "w0", "wa"])
+    param_names: list[str] = field(default_factory=lambda: ["H0", "Ωm", "Ωde", "w0", "wa"])
 
 @dataclass
 class Config:

--- a/cosmology/__init__.py
+++ b/cosmology/__init__.py
@@ -7,8 +7,8 @@ Cosmological models for Hubble inference.
 from cosmology.base import CosmologicalModel
 from cosmology.concordance import ConcordanceModel
 from cosmology.discordance import DiscordanceModel
-from cosmology.wcdm import WCDMModel
 from cosmology.early_de import EarlyDarkEnergyModel
+from cosmology.wcdm import WCDMModel
 
 __all__ = [
     "CosmologicalModel",

--- a/cosmology/base.py
+++ b/cosmology/base.py
@@ -10,12 +10,13 @@ Each model defines:
 """
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
-from typing import List, Dict, Callable, Optional, Tuple
-import torch
-import numpy as np
+from dataclasses import dataclass
+from typing import Optional
 
-from config import DEVICE, logger
+import numpy as np
+import torch
+
+from config import DEVICE
 
 
 @dataclass
@@ -82,7 +83,7 @@ class CosmologicalModel(ABC):
     """
 
     def __init__(self):
-        self._parameters: List[Parameter] = []
+        self._parameters: list[Parameter] = []
         self._setup_parameters()
 
     @property
@@ -108,7 +109,7 @@ class CosmologicalModel(ABC):
         pass
 
     @property
-    def parameters(self) -> List[Parameter]:
+    def parameters(self) -> list[Parameter]:
         """List of model parameters."""
         return self._parameters
 
@@ -118,12 +119,12 @@ class CosmologicalModel(ABC):
         return len(self._parameters)
 
     @property
-    def param_names(self) -> List[str]:
+    def param_names(self) -> list[str]:
         """List of parameter names."""
         return [p.name for p in self._parameters]
 
     @property
-    def param_symbols(self) -> List[str]:
+    def param_symbols(self) -> list[str]:
         """List of parameter symbols (for plotting)."""
         return [p.symbol for p in self._parameters]
 
@@ -217,7 +218,7 @@ class CosmologicalModel(ABC):
         pass
 
     @abstractmethod
-    def get_cosmology_params(self, theta: torch.Tensor) -> Dict[str, torch.Tensor]:
+    def get_cosmology_params(self, theta: torch.Tensor) -> dict[str, torch.Tensor]:
         """
         Convert parameter vector to dictionary of cosmological parameters.
 

--- a/cosmology/concordance.py
+++ b/cosmology/concordance.py
@@ -11,8 +11,8 @@ systematic errors, not new physics.
 Parameters: θ = (H₀, Ωm, Ωde, w₀, wa)
 """
 
+
 import torch
-from typing import Dict
 
 from cosmology.base import CosmologicalModel, Parameter
 
@@ -104,7 +104,7 @@ class ConcordanceModel(CosmologicalModel):
             return theta[0]
         return theta[:, 0]
 
-    def get_cosmology_params(self, theta: torch.Tensor) -> Dict[str, torch.Tensor]:
+    def get_cosmology_params(self, theta: torch.Tensor) -> dict[str, torch.Tensor]:
         """Extract cosmological parameters from theta vector."""
         if theta.dim() == 1:
             return {

--- a/cosmology/discordance.py
+++ b/cosmology/discordance.py
@@ -17,8 +17,8 @@ is "real" in a Bayesian sense.
 Parameters: θ = (H₀_early, H₀_late, Ωm, Ωde, w₀, wa)
 """
 
+
 import torch
-from typing import Dict
 
 from cosmology.base import CosmologicalModel, Parameter
 
@@ -120,7 +120,7 @@ class DiscordanceModel(CosmologicalModel):
             return theta[1]
         return theta[:, 1]
 
-    def get_cosmology_params(self, theta: torch.Tensor) -> Dict[str, torch.Tensor]:
+    def get_cosmology_params(self, theta: torch.Tensor) -> dict[str, torch.Tensor]:
         """Extract cosmological parameters from theta vector."""
         if theta.dim() == 1:
             return {

--- a/cosmology/early_de.py
+++ b/cosmology/early_de.py
@@ -15,8 +15,8 @@ This can bring early-universe H₀ into agreement with local measurements.
 Parameters: θ = (H₀, Ωm, Ωde, w₀, wa, f_ede, z_c)
 """
 
+
 import torch
-from typing import Dict
 
 from cosmology.base import CosmologicalModel, Parameter
 
@@ -147,7 +147,7 @@ class EarlyDarkEnergyModel(CosmologicalModel):
             return theta[0]
         return theta[:, 0]
 
-    def get_cosmology_params(self, theta: torch.Tensor) -> Dict[str, torch.Tensor]:
+    def get_cosmology_params(self, theta: torch.Tensor) -> dict[str, torch.Tensor]:
         """Extract all cosmological parameters."""
         if theta.dim() == 1:
             return {

--- a/cosmology/wcdm.py
+++ b/cosmology/wcdm.py
@@ -13,8 +13,8 @@ from ΛCDM, which could reconcile early and late H₀ measurements.
 Parameters: θ = (H₀, Ωm, Ωde, w₀, wa)
 """
 
+
 import torch
-from typing import Dict
 
 from cosmology.base import CosmologicalModel, Parameter
 
@@ -103,7 +103,7 @@ class WCDMModel(CosmologicalModel):
             return theta[0]
         return theta[:, 0]
 
-    def get_cosmology_params(self, theta: torch.Tensor) -> Dict[str, torch.Tensor]:
+    def get_cosmology_params(self, theta: torch.Tensor) -> dict[str, torch.Tensor]:
         """Extract cosmological parameters."""
         if theta.dim() == 1:
             return {

--- a/flow_train.py
+++ b/flow_train.py
@@ -18,15 +18,15 @@ Usage:
     # or via CLI: hubble train
 """
 
-import torch
-from torch.utils.data import DataLoader, TensorDataset, random_split
-from torch.optim.lr_scheduler import CosineAnnealingLR
 from pathlib import Path
-from typing import Optional, Dict, Any
-import json
+from typing import Any
 
+import torch
+from torch.optim.lr_scheduler import CosineAnnealingLR
+from torch.utils.data import DataLoader, TensorDataset, random_split
+
+from config import MODELS, config, logger, paths, set_seed
 from models import build_flow, save_flow
-from config import config, paths, DEVICE, MODELS, logger, set_seed
 
 # Try to import tqdm, fall back to simple progress
 try:
@@ -150,7 +150,7 @@ def train_flow(
     checkpoint_every: int = 5,
     resume: bool = True,
     model_name: str = None,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Train the normalizing flow on the provided data.
 
@@ -333,7 +333,7 @@ def train_flow(
         "early_stopped": early_stopping.should_stop,
         "model_name": model_name,
     }
-    save_flow(flow, metadata, model_name=model_name)
+    save_flow(flow, model_name=model_name, metadata=metadata)
 
     # Clean up checkpoint
     if checkpoint_path.exists():

--- a/forward.py
+++ b/forward.py
@@ -10,11 +10,10 @@ Two modes are supported:
 θ  = (H0, Ωm, Ωde, w0, wa)     shape (5,) or (batch, 5)
 """
 
-import torch
-import numpy as np
-from typing import Optional
 
-from config import config, paths, DEVICE, logger
+import torch
+
+from config import DEVICE, config, logger, paths
 
 # Speed of light in km/s
 C_LIGHT = 299792.458
@@ -32,8 +31,11 @@ def cmb_available() -> bool:
     global _cmb_available
     if _cmb_available is None:
         try:
-            import cosmopower as cp
-            _cmb_available = paths.cmb_emulator.exists()
+            import importlib.util
+            if importlib.util.find_spec("cosmopower") is not None:
+                _cmb_available = paths.cmb_emulator.exists()
+            else:
+                _cmb_available = False
         except ImportError:
             _cmb_available = False
     return _cmb_available
@@ -151,7 +153,7 @@ def comoving_distance(z: torch.Tensor, theta: torch.Tensor, n_points: int = None
         theta = theta.unsqueeze(0)
 
     batch_size = theta.shape[0]
-    n_z = z.shape[0]
+    z.shape[0]
     H0 = theta[:, 0]  # (batch,)
 
     # Create integration grid for all z values at once: (n_z, n_points)
@@ -161,7 +163,7 @@ def comoving_distance(z: torch.Tensor, theta: torch.Tensor, n_points: int = None
 
     # Compute E(z) for all (batch, n_z, n_points) combinations
     # Reshape for batch computation
-    z_flat = z_grid.reshape(-1)  # (n_z * n_points,)
+    z_grid.reshape(-1)  # (n_z * n_points,)
 
     # Compute 1/E(z) for the entire grid
     Om = theta[:, 1:2]    # (batch, 1)

--- a/inference/__init__.py
+++ b/inference/__init__.py
@@ -4,9 +4,9 @@ inference/__init__.py
 Inference modules for Hubble.
 """
 
-from inference.evidence import estimate_log_evidence, compute_evidence_ratio
-from inference.tension import TensionAnalyzer
 from inference.comparison import ModelComparison
+from inference.evidence import compute_evidence_ratio, estimate_log_evidence
+from inference.tension import TensionAnalyzer
 
 __all__ = [
     "estimate_log_evidence",

--- a/inference/evidence.py
+++ b/inference/evidence.py
@@ -11,12 +11,12 @@ This is the key quantity for Bayesian model comparison.
 We estimate it using importance sampling from the flow posterior.
 """
 
-import torch
-import numpy as np
-from typing import Optional, Tuple, Dict
 from dataclasses import dataclass
 
-from config import DEVICE, logger
+import numpy as np
+import torch
+
+from config import logger
 from cosmology.base import CosmologicalModel
 
 
@@ -169,7 +169,7 @@ def compute_evidence_ratio(
     model2: CosmologicalModel,
     x_obs: torch.Tensor,
     n_samples: int = 50000,
-) -> Dict:
+) -> dict:
     """
     Compute the Bayes factor (evidence ratio) between two models.
 

--- a/inference/model_selection.py
+++ b/inference/model_selection.py
@@ -15,10 +15,10 @@ These are useful when evidence estimation is uncertain or computationally
 expensive, and provide different perspectives on model complexity penalties.
 """
 
-import torch
-import numpy as np
-from typing import Dict, NamedTuple, Optional
 from dataclasses import dataclass
+
+import numpy as np
+import torch
 
 from config import logger
 
@@ -40,7 +40,7 @@ class ModelSelectionResult:
     dic: float
     waic: float
 
-    def to_dict(self) -> Dict:
+    def to_dict(self) -> dict:
         """Convert to dictionary."""
         return {
             "model_name": self.model_name,
@@ -285,7 +285,7 @@ def compute_all_criteria(
 
 def compare_models(
     results: list[ModelSelectionResult],
-) -> Dict[str, Dict[str, float]]:
+) -> dict[str, dict[str, float]]:
     """
     Compare multiple models using all criteria.
 
@@ -320,7 +320,7 @@ def compare_models(
 
 def format_comparison_table(
     results: list[ModelSelectionResult],
-    comparison: Dict[str, Dict[str, float]],
+    comparison: dict[str, dict[str, float]],
 ) -> str:
     """
     Format comparison results as a readable table.

--- a/inference/tension.py
+++ b/inference/tension.py
@@ -15,12 +15,13 @@ assuming they measure the same thing. Bayesian analysis tells you the
 probability they actually do measure the same thing.
 """
 
-import torch
-import numpy as np
-from typing import Dict, Optional, Tuple, List
 from dataclasses import dataclass
+from typing import Optional
 
-from config import DEVICE, logger
+import numpy as np
+import torch
+
+from config import logger
 from cosmology.base import CosmologicalModel
 
 
@@ -38,8 +39,8 @@ class TensionResult:
     delta_H0_median: float
 
     # Credible intervals for ΔH₀
-    delta_H0_ci68: Tuple[float, float]
-    delta_H0_ci95: Tuple[float, float]
+    delta_H0_ci68: tuple[float, float]
+    delta_H0_ci95: tuple[float, float]
 
     # Derived
     sigma_tension: float  # Effective tension in sigma
@@ -141,8 +142,8 @@ class TensionAnalyzer:
     def probability_curve(
         self,
         theta_samples: torch.Tensor,
-        epsilon_range: Optional[List[float]] = None
-    ) -> Dict[str, np.ndarray]:
+        epsilon_range: Optional[list[float]] = None
+    ) -> dict[str, np.ndarray]:
         """
         Compute P(|ΔH₀| < ε) for a range of ε values.
 
@@ -223,7 +224,7 @@ class TensionAnalyzer:
         theta_samples: torch.Tensor,
         early_only_samples: torch.Tensor,
         late_only_samples: torch.Tensor,
-    ) -> Dict:
+    ) -> dict:
         """
         Compare posterior constraints from different data subsets.
 
@@ -270,7 +271,7 @@ def compute_suspiciousness(
     theta_samples_1: torch.Tensor,
     theta_samples_2: torch.Tensor,
     model: CosmologicalModel,
-) -> Dict:
+) -> dict:
     """
     Compute the "suspiciousness" statistic for dataset tension.
 

--- a/main.py
+++ b/main.py
@@ -23,10 +23,11 @@ Visualization:
     hubble plot-tension        # Plot tension probability curve
 """
 
-import click
 from pathlib import Path
 
-from config import logger, set_seed, RESULTS
+import click
+
+from config import RESULTS, logger, set_seed
 
 
 @click.group()
@@ -191,8 +192,6 @@ def train_model(model_name: str, n_samples: int, epochs: int, batch_size: int, l
 
     from cosmology import get_model
     from models import build_flow_for_model, save_flow
-    from config import config, paths, DEVICE
-    import forward
 
     logger.info("=" * 60)
     logger.info(f"Training flow for model: {model_name}")
@@ -280,10 +279,11 @@ def compare_models(models: tuple, n_samples: int, epsilon: float, output: str):
     - Tension resolution probability under each model
     """
     import torch
+
+    from config import DEVICE, paths
     from cosmology import get_model
-    from models import load_flow, check_flow_exists
-    from config import paths, DEVICE
     from inference.comparison import ModelComparison
+    from models import check_flow_exists, load_flow
 
     logger.info("=" * 60)
     logger.info("Bayesian Model Comparison")
@@ -341,10 +341,11 @@ def tension_analysis(model: str, n_samples: int, epsilon: float):
     - Resolution probability curve
     """
     import torch
+
+    from config import DEVICE, paths
     from cosmology import get_model
-    from models import load_flow, check_flow_exists
-    from config import paths, DEVICE
     from inference.tension import TensionAnalyzer
+    from models import check_flow_exists, load_flow
 
     logger.info("=" * 60)
     logger.info(f"Hubble Tension Analysis ({model})")
@@ -409,10 +410,11 @@ def tension_analysis(model: str, n_samples: int, epsilon: float):
 def plot_corner_cmd(model: str, output: str):
     """Generate a corner plot of posterior samples."""
     import torch
-    from cosmology import get_model
-    from models import load_flow, check_flow_exists
-    from config import paths, DEVICE, RESULTS
+
     from analysis.visualize import plot_corner
+    from config import DEVICE, paths
+    from cosmology import get_model
+    from models import check_flow_exists, load_flow
 
     if not check_flow_exists(model):
         raise click.ClickException(f"No trained flow for '{model}'.")
@@ -445,11 +447,12 @@ def plot_corner_cmd(model: str, output: str):
 def plot_tension_cmd(model: str, output: str):
     """Plot the tension resolution probability curve."""
     import torch
-    from cosmology import get_model
-    from models import load_flow, check_flow_exists
-    from config import paths, DEVICE, RESULTS
-    from inference.tension import TensionAnalyzer
+
     from analysis.visualize import plot_tension_curve
+    from config import DEVICE, paths
+    from cosmology import get_model
+    from inference.tension import TensionAnalyzer
+    from models import check_flow_exists, load_flow
 
     if not check_flow_exists(model):
         raise click.ClickException(f"No trained flow for '{model}'.")
@@ -485,7 +488,8 @@ def plot_tension_cmd(model: str, output: str):
 def info():
     """Display configuration and system information."""
     import torch
-    from config import config, DEVICE, paths, ROOT
+
+    from config import DEVICE, ROOT, config, paths
 
     click.echo("\nHubble Configuration")
     click.echo("=" * 50)
@@ -496,17 +500,17 @@ def info():
     if torch.cuda.is_available():
         click.echo(f"CUDA device: {torch.cuda.get_device_name(0)}")
 
-    click.echo(f"\nFlow architecture:")
+    click.echo("\nFlow architecture:")
     click.echo(f"  Hidden dim: {config.flow.hidden_dim}")
     click.echo(f"  Layers: {config.flow.n_layers}")
 
-    click.echo(f"\nTraining config:")
+    click.echo("\nTraining config:")
     click.echo(f"  Default samples: {config.training.n_train_samples:,}")
     click.echo(f"  Batch size: {config.training.batch_size}")
     click.echo(f"  Learning rate: {config.training.learning_rate}")
     click.echo(f"  Epochs: {config.training.n_epochs}")
 
-    click.echo(f"\nInference config:")
+    click.echo("\nInference config:")
     click.echo(f"  Posterior samples: {config.inference.n_posterior_samples:,}")
 
     # Available models
@@ -518,7 +522,7 @@ def info():
     available = list_available_flows()
     click.echo(f"Trained flows: {', '.join(available) if available else 'None'}")
 
-    click.echo(f"\nData paths:")
+    click.echo("\nData paths:")
     click.echo(f"  Raw: {paths.pantheon_data.parent}")
     click.echo(f"  Processed: {paths.obs_h5.parent}")
     click.echo(f"  Models: {paths.flow_weights.parent}")

--- a/models.py
+++ b/models.py
@@ -7,15 +7,15 @@ This ensures flow architecture is defined in ONE place only.
 Supports multiple cosmological models with different parameter dimensions.
 """
 
+from pathlib import Path
+from typing import Union
+
 import torch
-import nflows
-from nflows.transforms import MaskedAffineAutoregressiveTransform, CompositeTransform
 from nflows.distributions import StandardNormal
 from nflows.flows import Flow
-from pathlib import Path
-from typing import Optional, Union
+from nflows.transforms import CompositeTransform, MaskedAffineAutoregressiveTransform
 
-from config import config, paths, DEVICE, MODELS, logger
+from config import DEVICE, MODELS, config, logger, paths
 
 
 def build_flow(

--- a/posterior.py
+++ b/posterior.py
@@ -13,8 +13,8 @@ Usage:
 
 import torch
 
+from config import DEVICE, config, logger, paths, set_seed
 from models import load_flow
-from config import config, paths, DEVICE, logger, set_seed
 
 
 def load_observed_summary() -> torch.Tensor:

--- a/prep.py
+++ b/prep.py
@@ -11,11 +11,11 @@ Usage:
     # or via CLI: hubble prep
 """
 
-import numpy as np
 import h5py
+import numpy as np
 import torch
 
-from config import paths, DEVICE, logger
+from config import DEVICE, logger, paths
 
 
 def validate_input_files() -> None:

--- a/prob.py
+++ b/prob.py
@@ -14,10 +14,10 @@ Usage:
     # or via CLI: hubble analyze
 """
 
-import torch
 import numpy as np
+import torch
 
-from config import config, paths, logger
+from config import config, logger, paths
 
 
 def load_posterior() -> torch.Tensor:
@@ -114,7 +114,7 @@ def compute_posterior_statistics(θ: torch.Tensor) -> dict:
     return stats
 
 
-def run(epsilon: float = 1.0) -> None:
+def run(epsilon: float = 1.0) -> dict:
     """
     Run the full analysis pipeline.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,8 @@ target-version = ["py39", "py310", "py311"]
 
 [tool.ruff]
 line-length = 100
+
+[tool.ruff.lint]
 select = ["E", "F", "W", "I", "UP", "B", "C4"]
 ignore = ["E501"]
 

--- a/setup_data.py
+++ b/setup_data.py
@@ -14,14 +14,13 @@ Usage:
     python setup_data.py --both      # Both
 """
 
-import numpy as np
-from pathlib import Path
-import urllib.request
 import ssl
-import warnings
+import urllib.request
+from pathlib import Path
 
-from config import DATA_RAW, DATA_PROC, logger
+import numpy as np
 
+from config import DATA_RAW, logger
 
 # =============================================================================
 # Real Data URLs
@@ -221,7 +220,7 @@ def save_synthetic_data(sn_data: dict, bao_data: dict) -> None:
         "wa": 0.0,
     }
     np.save(DATA_RAW / "true_params.npy", true_params)
-    logger.info(f"Saved true parameters for validation")
+    logger.info("Saved true parameters for validation")
 
 
 # =============================================================================
@@ -301,8 +300,8 @@ def setup_synthetic(
     logger.info(f"  H0 = {H0} km/s/Mpc")
     logger.info(f"  Om = {Om}")
     logger.info(f"  Ode = {1-Om}")
-    logger.info(f"  w0 = -1.0 (ΛCDM)")
-    logger.info(f"  wa = 0.0")
+    logger.info("  w0 = -1.0 (ΛCDM)")
+    logger.info("  wa = 0.0")
     logger.info("")
     logger.info("Use these to validate posterior recovery!")
 

--- a/sim.py
+++ b/sim.py
@@ -11,12 +11,12 @@ Usage:
     # or via CLI: hubble simulate
 """
 
-import torch
 import sobol_seq
+import torch
 
 import forward
 import prep
-from config import config, paths, DEVICE, logger, set_seed
+from config import DEVICE, config, logger, paths, set_seed
 
 # Try to import tqdm for progress bars
 try:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,6 @@ test_config.py
 Unit tests for configuration module.
 """
 
-import pytest
 import sys
 from pathlib import Path
 
@@ -30,7 +29,7 @@ class TestPaths:
 
     def test_directories_created(self):
         """Data directories should be created on import."""
-        from config import DATA_RAW, DATA_PROC, MODELS, RESULTS
+        from config import DATA_PROC, DATA_RAW, MODELS, RESULTS
         assert DATA_RAW.exists()
         assert DATA_PROC.exists()
         assert MODELS.exists()
@@ -82,6 +81,7 @@ class TestDevice:
     def test_device_is_valid(self):
         """DEVICE should be a valid torch device."""
         import torch
+
         from config import DEVICE
         assert isinstance(DEVICE, torch.device)
         assert DEVICE.type in ["cpu", "cuda", "mps"]
@@ -99,6 +99,7 @@ class TestSeed:
     def test_set_seed(self):
         """set_seed should make torch operations deterministic."""
         import torch
+
         from config import set_seed
 
         set_seed(42)
@@ -112,6 +113,7 @@ class TestSeed:
     def test_different_seeds_give_different_results(self):
         """Different seeds should give different random values."""
         import torch
+
         from config import set_seed
 
         set_seed(42)

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -14,11 +14,11 @@ This test runs through the full workflow:
 Run with: pytest tests/test_end_to_end.py -v
 """
 
+import sys
+from pathlib import Path
+
 import pytest
 import torch
-import numpy as np
-from pathlib import Path
-import sys
 
 # Add parent directory to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -30,14 +30,18 @@ class TestEndToEnd:
     @pytest.fixture(autouse=True)
     def setup(self):
         """Set up test fixtures."""
-        from config import DEVICE, DATA_RAW, DATA_PROC
+        from config import DATA_PROC, DATA_RAW, DEVICE
         self.device = DEVICE
         self.data_raw = DATA_RAW
         self.data_proc = DATA_PROC
 
     def test_01_generate_synthetic_data(self):
         """Test synthetic data generation."""
-        from setup_data import generate_synthetic_sn_data, generate_synthetic_bao_data, save_synthetic_data
+        from setup_data import (
+            generate_synthetic_bao_data,
+            generate_synthetic_sn_data,
+            save_synthetic_data,
+        )
 
         # Generate with known parameters
         sn_data = generate_synthetic_sn_data(
@@ -128,8 +132,8 @@ class TestEndToEnd:
 
     def test_05_summary_vector(self):
         """Test summary vector construction."""
-        import prep
         import forward
+        import prep
 
         obs = prep.load_observations()
         theta = torch.tensor([70.0, 0.3, 0.7, -1.0, 0.0], device=self.device)
@@ -145,8 +149,8 @@ class TestEndToEnd:
 
     def test_06_chi_squared(self):
         """Test chi-squared calculation."""
-        import prep
         import forward
+        import prep
 
         obs = prep.load_observations()
 
@@ -178,10 +182,10 @@ class TestEndToEnd:
 
     def test_08_mini_training(self):
         """Test a minimal training run."""
-        import prep
         import forward
-        from models import build_flow
+        import prep
         from config import DEVICE
+        from models import build_flow
 
         obs = prep.load_observations()
 
@@ -222,10 +226,10 @@ class TestEndToEnd:
 
     def test_09_posterior_sampling(self):
         """Test posterior sampling from trained flow."""
-        import prep
         import forward
-        from models import build_flow
+        import prep
         from config import DEVICE
+        from models import build_flow
 
         obs = prep.load_observations()
 

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -4,16 +4,16 @@ test_forward.py
 Unit tests for the forward model (cosmological calculations).
 """
 
-import pytest
-import torch
 import sys
 from pathlib import Path
+
+import torch
 
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from forward import Ez, comoving_distance, volume_distance, luminosity_distance
 from config import DEVICE
+from forward import Ez, comoving_distance, luminosity_distance, volume_distance
 
 
 class TestEz:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,10 +4,10 @@ test_models.py
 Unit tests for model building and loading.
 """
 
-import pytest
-import torch
 import sys
 from pathlib import Path
+
+import torch
 
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -50,8 +50,8 @@ class TestBuildFlow:
 
     def test_flow_can_compute_log_prob(self):
         """Flow should compute log probabilities."""
-        from models import build_flow
         from config import DEVICE
+        from models import build_flow
 
         flow = build_flow(dim=5)
 
@@ -65,8 +65,8 @@ class TestBuildFlow:
 
     def test_flow_on_correct_device(self):
         """Flow should be on the specified device."""
-        from models import build_flow
         from config import DEVICE
+        from models import build_flow
 
         flow = build_flow()
 
@@ -80,8 +80,8 @@ class TestFlowGradients:
 
     def test_gradients_flow_during_training(self):
         """Gradients should flow through the model."""
-        from models import build_flow
         from config import DEVICE
+        from models import build_flow
 
         flow = build_flow(dim=5)
 

--- a/x_obs.py
+++ b/x_obs.py
@@ -19,12 +19,12 @@ Usage:
 """
 
 import warnings
+
 import torch
 
 import forward
 import prep
-from config import paths, DEVICE, logger
-
+from config import DEVICE, logger, paths
 
 # Fiducial cosmological parameters for summary vector construction
 # These should be updated based on external constraints (e.g., Planck best-fit)


### PR DESCRIPTION
- Fix save_flow() argument order bug in flow_train.py:336
  - Was passing metadata as positional arg for model_name
  - Changed to use keyword arguments correctly

- Update pyproject.toml ruff config to new format
  - Move select/ignore to [tool.ruff.lint] section

- Fix all ruff linting issues:
  - Sort imports (I001)
  - Update deprecated typing imports (Dict->dict, List->list, Tuple->tuple)
  - Remove unused imports (F401)
  - Add proper exception chaining (raise ... from err)
  - Add stacklevel to warnings.warn()
  - Remove unused variables

- Fix prob.py return type annotation (-> dict, not -> None)

- Use importlib.util.find_spec for cosmopower availability check
  - Avoids unused import warning

All files compile successfully. Ruff passes with no errors.